### PR TITLE
Update Nix derivation attributes

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -3,13 +3,13 @@
 with pkgs;
 buildGoModule rec {
   pname = "jsonnet-language-server";
-  version = "0.3.0";
+  version = "0.6.3";
 
   ldflags = ''
     -X main.version=${version}
   '';
-  src = lib.cleanSource ./.;
-  vendorSha256 = "sha256-8jX2we1fpVmjhwcaLZ584MdbkvnrcDNAw9xKhT/z740=";
+  src = lib.cleanSource ../.;
+  vendorSha256 = "sha256-mGocX5z3wf9KRhE9leLNCzn8sVdjKJo6FzgP1OwQB3M=";
 
   meta = with lib; {
     description = "A Language Server Protocol server for Jsonnet";

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -5,8 +5,7 @@ buildGoModule rec {
   pname = "jsonnet-language-server";
   version = "0.3.0";
 
-  buildFlagsArray = ''
-    -ldflags=
+  ldflags = ''
     -X main.version=${version}
   '';
   src = lib.cleanSource ./.;


### PR DESCRIPTION
- Replace deprecated `buildFlagsArray` argument with `ldflags` attribute (see [here](https://github.com/NixOS/nixpkgs/blob/b99fc173da1621ddb933c081e79e22d44d489b23/pkgs/development/go-modules/generic/default.nix#L274-L276))
- Update version to `0.6.3`
- Point `src` to repository root (`../.`)

Tested successfully with on macOS Monterey (12.0.1):

```bash
$ nix build ./nix
$ ./result/bin/jsonnet-language-server --version
jsonnet-language-server version 0.6.3
```