### PR TITLE
Return multiple definitions: Simple cases

### DIFF
--- a/pkg/server/definition_test.go
+++ b/pkg/server/definition_test.go
@@ -498,6 +498,43 @@ func TestDefinition(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:     "goto with overrides: overridden nested map",
+			filename: "testdata/goto-overrides.jsonnet",
+			position: protocol.Position{Line: 33, Character: 34},
+			results: []definitionResult{
+				{
+					targetRange: protocol.Range{
+						Start: protocol.Position{Line: 25, Character: 4},
+						End:   protocol.Position{Line: 27, Character: 5},
+					},
+					targetSelectionRange: protocol.Range{
+						Start: protocol.Position{Line: 25, Character: 4},
+						End:   protocol.Position{Line: 25, Character: 11},
+					},
+				},
+				{
+					targetRange: protocol.Range{
+						Start: protocol.Position{Line: 16, Character: 4},
+						End:   protocol.Position{Line: 18, Character: 5},
+					},
+					targetSelectionRange: protocol.Range{
+						Start: protocol.Position{Line: 16, Character: 4},
+						End:   protocol.Position{Line: 16, Character: 11},
+					},
+				},
+				{
+					targetRange: protocol.Range{
+						Start: protocol.Position{Line: 4, Character: 4},
+						End:   protocol.Position{Line: 6, Character: 5},
+					},
+					targetSelectionRange: protocol.Range{
+						Start: protocol.Position{Line: 4, Character: 4},
+						End:   protocol.Position{Line: 4, Character: 11},
+					},
+				},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/server/definition_test.go
+++ b/pkg/server/definition_test.go
@@ -462,7 +462,7 @@ func TestDefinition(t *testing.T) {
 			}},
 		},
 		{
-			name:     "goto with overrides: overridden map",
+			name:     "goto with overrides: map (multiple definitions)",
 			filename: "testdata/goto-overrides.jsonnet",
 			position: protocol.Position{Line: 32, Character: 22},
 			results: []definitionResult{
@@ -499,7 +499,7 @@ func TestDefinition(t *testing.T) {
 			},
 		},
 		{
-			name:     "goto with overrides: overridden nested map",
+			name:     "goto with overrides: nested map (multiple definitions)",
 			filename: "testdata/goto-overrides.jsonnet",
 			position: protocol.Position{Line: 33, Character: 34},
 			results: []definitionResult{
@@ -534,6 +534,36 @@ func TestDefinition(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			name:     "goto with overrides: string carried from super",
+			filename: "testdata/goto-overrides.jsonnet",
+			position: protocol.Position{Line: 35, Character: 27},
+			results: []definitionResult{{
+				targetRange: protocol.Range{
+					Start: protocol.Position{Line: 3, Character: 4},
+					End:   protocol.Position{Line: 3, Character: 18},
+				},
+				targetSelectionRange: protocol.Range{
+					Start: protocol.Position{Line: 3, Character: 4},
+					End:   protocol.Position{Line: 3, Character: 9},
+				},
+			}},
+		},
+		{
+			name:     "goto with overrides: nested string carried from super",
+			filename: "testdata/goto-overrides.jsonnet",
+			position: protocol.Position{Line: 36, Character: 44},
+			results: []definitionResult{{
+				targetRange: protocol.Range{
+					Start: protocol.Position{Line: 17, Character: 6},
+					End:   protocol.Position{Line: 17, Character: 22},
+				},
+				targetSelectionRange: protocol.Range{
+					Start: protocol.Position{Line: 17, Character: 6},
+					End:   protocol.Position{Line: 17, Character: 12},
+				},
+			}},
 		},
 	}
 	for _, tc := range testCases {

--- a/pkg/server/definition_test.go
+++ b/pkg/server/definition_test.go
@@ -461,6 +461,43 @@ func TestDefinition(t *testing.T) {
 				},
 			}},
 		},
+		{
+			name:     "goto with overrides: overridden map",
+			filename: "testdata/goto-overrides.jsonnet",
+			position: protocol.Position{Line: 32, Character: 22},
+			results: []definitionResult{
+				{
+					targetRange: protocol.Range{
+						Start: protocol.Position{Line: 23, Character: 2},
+						End:   protocol.Position{Line: 29, Character: 3},
+					},
+					targetSelectionRange: protocol.Range{
+						Start: protocol.Position{Line: 23, Character: 2},
+						End:   protocol.Position{Line: 23, Character: 3},
+					},
+				},
+				{
+					targetRange: protocol.Range{
+						Start: protocol.Position{Line: 14, Character: 2},
+						End:   protocol.Position{Line: 19, Character: 3},
+					},
+					targetSelectionRange: protocol.Range{
+						Start: protocol.Position{Line: 14, Character: 2},
+						End:   protocol.Position{Line: 14, Character: 3},
+					},
+				},
+				{
+					targetRange: protocol.Range{
+						Start: protocol.Position{Line: 2, Character: 2},
+						End:   protocol.Position{Line: 10, Character: 3},
+					},
+					targetSelectionRange: protocol.Range{
+						Start: protocol.Position{Line: 2, Character: 2},
+						End:   protocol.Position{Line: 2, Character: 3},
+					},
+				},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/server/utils_test.go
+++ b/pkg/server/utils_test.go
@@ -11,8 +11,13 @@ import (
 	"github.com/grafana/jsonnet-language-server/pkg/utils"
 	"github.com/jdbaldry/go-language-server-protocol/jsonrpc2"
 	"github.com/jdbaldry/go-language-server-protocol/lsp/protocol"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
+
+func init() {
+	logrus.SetLevel(logrus.WarnLevel)
+}
 
 func absUri(t *testing.T, path string) protocol.DocumentURI {
 	t.Helper()


### PR DESCRIPTION
Handles all cases from the new `goto-overrides.jsonnet` file. Example:

![image](https://user-images.githubusercontent.com/29210090/153965290-898ee9d6-e0cf-4d88-8bad-391021be96b6.png)

There are still some cases to consider for https://github.com/grafana/jsonnet-language-server/issues/6 (like considering multiple definitions when an import is considered), so it's not ready to close yet