### PR TITLE
Support multiple definitions: Locals

### DIFF
--- a/pkg/processing/find_field.go
+++ b/pkg/processing/find_field.go
@@ -122,7 +122,14 @@ func FindRangesFromIndexList(stack *nodestack.NodeStack, indexList []string, vm 
 		for _, foundField := range foundFields {
 			switch fieldNode := foundField.Body.(type) {
 			case *ast.Var:
-				bind := FindBindByIdViaStack(stack, fieldNode.Id)
+				// If the field is a var, we need to find the value of the var
+				// To do so, we get the stack where the var is used and search that stack for the var's definition
+				varFileNode, _, _ := vm.ImportAST("", fieldNode.LocRange.FileName)
+				varStack, err := FindNodeByPosition(varFileNode, fieldNode.Loc().Begin)
+				if err != nil {
+					return nil, fmt.Errorf("got the following error when finding the bind for %s: %w", fieldNode.Id, err)
+				}
+				bind := FindBindByIdViaStack(varStack, fieldNode.Id)
 				if bind == nil {
 					return nil, fmt.Errorf("could not find bind for %s", fieldNode.Id)
 				}

--- a/pkg/server/definition_test.go
+++ b/pkg/server/definition_test.go
@@ -419,7 +419,7 @@ func TestDefinition(t *testing.T) {
 		{
 			name:     "goto with overrides: clobber string",
 			filename: "testdata/goto-overrides.jsonnet",
-			position: protocol.Position{Line: 38, Character: 30},
+			position: protocol.Position{Line: 39, Character: 30},
 			results: []definitionResult{{
 				targetRange: protocol.Range{
 					Start: protocol.Position{Line: 24, Character: 4},
@@ -434,7 +434,7 @@ func TestDefinition(t *testing.T) {
 		{
 			name:     "goto with overrides: clobber nested string",
 			filename: "testdata/goto-overrides.jsonnet",
-			position: protocol.Position{Line: 39, Character: 44},
+			position: protocol.Position{Line: 40, Character: 44},
 			results: []definitionResult{{
 				targetRange: protocol.Range{
 					Start: protocol.Position{Line: 26, Character: 6},
@@ -449,7 +449,7 @@ func TestDefinition(t *testing.T) {
 		{
 			name:     "goto with overrides: clobber map",
 			filename: "testdata/goto-overrides.jsonnet",
-			position: protocol.Position{Line: 40, Character: 28},
+			position: protocol.Position{Line: 41, Character: 28},
 			results: []definitionResult{{
 				targetRange: protocol.Range{
 					Start: protocol.Position{Line: 28, Character: 4},
@@ -499,19 +499,19 @@ func TestDefinition(t *testing.T) {
 				{
 					targetFilename: "testdata/goto-overrides-base.jsonnet",
 					targetRange: protocol.Range{
-						Start: protocol.Position{Line: 18, Character: 2},
-						End:   protocol.Position{Line: 18, Character: 24},
+						Start: protocol.Position{Line: 16, Character: 2},
+						End:   protocol.Position{Line: 16, Character: 24},
 					},
 					targetSelectionRange: protocol.Range{
-						Start: protocol.Position{Line: 18, Character: 2},
-						End:   protocol.Position{Line: 18, Character: 3},
+						Start: protocol.Position{Line: 16, Character: 2},
+						End:   protocol.Position{Line: 16, Character: 3},
 					},
 				},
 				{
 					targetFilename: "testdata/goto-overrides-base.jsonnet",
 					targetRange: protocol.Range{
 						Start: protocol.Position{Line: 1, Character: 2},
-						End:   protocol.Position{Line: 9, Character: 3},
+						End:   protocol.Position{Line: 7, Character: 3},
 					},
 					targetSelectionRange: protocol.Range{
 						Start: protocol.Position{Line: 1, Character: 2},
@@ -553,6 +553,28 @@ func TestDefinition(t *testing.T) {
 					targetSelectionRange: protocol.Range{
 						Start: protocol.Position{Line: 4, Character: 4},
 						End:   protocol.Position{Line: 4, Character: 11},
+					},
+				},
+				{
+					targetFilename: "testdata/goto-overrides-base.jsonnet",
+					targetRange: protocol.Range{
+						Start: protocol.Position{Line: 12, Character: 4},
+						End:   protocol.Position{Line: 14, Character: 5},
+					},
+					targetSelectionRange: protocol.Range{
+						Start: protocol.Position{Line: 12, Character: 4},
+						End:   protocol.Position{Line: 12, Character: 11},
+					},
+				},
+				{
+					targetFilename: "testdata/goto-overrides-base.jsonnet",
+					targetRange: protocol.Range{
+						Start: protocol.Position{Line: 3, Character: 4},
+						End:   protocol.Position{Line: 5, Character: 5},
+					},
+					targetSelectionRange: protocol.Range{
+						Start: protocol.Position{Line: 3, Character: 4},
+						End:   protocol.Position{Line: 3, Character: 11},
 					},
 				},
 			},

--- a/pkg/server/definition_test.go
+++ b/pkg/server/definition_test.go
@@ -496,6 +496,28 @@ func TestDefinition(t *testing.T) {
 						End:   protocol.Position{Line: 2, Character: 3},
 					},
 				},
+				{
+					targetFilename: "testdata/goto-overrides-base.jsonnet",
+					targetRange: protocol.Range{
+						Start: protocol.Position{Line: 18, Character: 2},
+						End:   protocol.Position{Line: 18, Character: 24},
+					},
+					targetSelectionRange: protocol.Range{
+						Start: protocol.Position{Line: 18, Character: 2},
+						End:   protocol.Position{Line: 18, Character: 3},
+					},
+				},
+				{
+					targetFilename: "testdata/goto-overrides-base.jsonnet",
+					targetRange: protocol.Range{
+						Start: protocol.Position{Line: 1, Character: 2},
+						End:   protocol.Position{Line: 9, Character: 3},
+					},
+					targetSelectionRange: protocol.Range{
+						Start: protocol.Position{Line: 1, Character: 2},
+						End:   protocol.Position{Line: 1, Character: 3},
+					},
+				},
 			},
 		},
 		{

--- a/pkg/server/testdata/goto-overrides-base.jsonnet
+++ b/pkg/server/testdata/goto-overrides-base.jsonnet
@@ -1,19 +1,17 @@
 {
   a: {
-    hello: 'this',
+    hello: 'this will be clobbered',
     nested1: {
-      hello: 'will be',
+      hello: 'this will be clobbered',
     },
-    nested2: {
-      hello: 'clobbered',
-    },
+    nested2: {},
   },
 
 }
 + {
   local extensionFromLocal = {
-    nested1: {
-      this: 'will also be clobbered',
+    nested1+: {
+      from_local: 'hey!',
     },
   },
   a+: extensionFromLocal,

--- a/pkg/server/testdata/goto-overrides-base.jsonnet
+++ b/pkg/server/testdata/goto-overrides-base.jsonnet
@@ -1,0 +1,20 @@
+{
+  a: {
+    hello: 'this',
+    nested1: {
+      hello: 'will be',
+    },
+    nested2: {
+      hello: 'clobbered',
+    },
+  },
+
+}
++ {
+  local extensionFromLocal = {
+    nested1: {
+      this: 'will also be clobbered',
+    },
+  },
+  a+: extensionFromLocal,
+}

--- a/pkg/server/testdata/goto-overrides.jsonnet
+++ b/pkg/server/testdata/goto-overrides.jsonnet
@@ -1,6 +1,6 @@
-{
-  // 1. Initial definition
-  a: {
+(import 'goto-overrides-base.jsonnet') {
+  // 1. Initial definition (overrides everything in the base, except the "a" map)
+  a+: {
     hello: 'world',
     nested1: {
       hello: 'world',

--- a/pkg/server/testdata/goto-overrides.jsonnet
+++ b/pkg/server/testdata/goto-overrides.jsonnet
@@ -1,8 +1,8 @@
-(import 'goto-overrides-base.jsonnet') {
-  // 1. Initial definition (overrides everything in the base, except the "a" map)
+(import 'goto-overrides-base.jsonnet')  // 1. Initial definition from base file
+{  // 2. Override nested string
   a+: {
     hello: 'world',
-    nested1: {
+    nested1+: {
       hello: 'world',
     },
     nested2: {
@@ -11,7 +11,7 @@
   },
 }
 + {
-  // 2. Override maps but keep string keys
+  // 3. Override maps but keep string keys
   a+: {
     hello2: 'world2',
     nested1+: {
@@ -20,7 +20,7 @@
   },
 }
 + {
-  // 3. Clobber some attributes
+  // 4. Clobber some attributes
   a+: {
     hello2: 'clobbered',  // Clobber a string
     nested1+: {
@@ -30,13 +30,14 @@
   },
 }
 + {
-  map_overrides: self.a,  // This should refer to all three definitions (initial + 2 overrides)
-  nested_map_overrides: self.a.nested1,  // This should refer to all three definitions (initial + 2 overrides)
+  map_overrides: self.a,  // This should refer to all definitions
+  nested_map_overrides: self.a.nested1,  // This should refer to all definitions
 
-  carried_string: self.a.hello,  // This should refer to the initial definition (map 1)
-  carried_nested_string: self.a.nested1.hello2,  // This should refer to the initial definition (map 2)
+  carried_string: self.a.hello,  // This should refer to the initial definition (map 2)
+  carried_nested_string: self.a.nested1.hello2,  // This should refer to the initial definition (map 3)
+  carried_nested_string_from_local: self.a.nested1.from_local,  // This should refer to the definition specified in a local in the base file
 
-  clobbered_string: self.a.hello2,  // This should refer to the override only (map 3)
-  clobbered_nested_string: self.a.nested1.hello,  // This should refer to the override only (map 3)
-  clobbered_map: self.a.nested2,  // This should refer to the override only (map 3)
+  clobbered_string: self.a.hello2,  // This should refer to the override only (map 4)
+  clobbered_nested_string: self.a.nested1.hello,  // This should refer to the override only (map 4)
+  clobbered_map: self.a.nested2,  // This should refer to the override only (map 4)
 }


### PR DESCRIPTION
Yet another case for https://github.com/grafana/jsonnet-language-server/issues/6
This supports two cases:
- Definitions across multiple files
- The case where a local is used in the second file. We were currently using the initial stack to find the bind for that var. Across files, that doesn't work, we have to work with the stack where the var is being used