### PR TITLE
Support multiple definitons: Binary operators

### DIFF
--- a/pkg/processing/find_field.go
+++ b/pkg/processing/find_field.go
@@ -119,8 +119,20 @@ func FindRangesFromIndexList(stack *nodestack.NodeStack, indexList []string, vm 
 			return ranges, nil
 		}
 
+		// Unpack binary nodes. A field could be either in the left or right side of the binary
+		var fieldNodes []ast.Node
 		for _, foundField := range foundFields {
 			switch fieldNode := foundField.Body.(type) {
+			case *ast.Binary:
+				fieldNodes = append(fieldNodes, fieldNode.Right)
+				fieldNodes = append(fieldNodes, fieldNode.Left)
+			default:
+				fieldNodes = append(fieldNodes, fieldNode)
+			}
+		}
+
+		for _, fieldNode := range fieldNodes {
+			switch fieldNode := fieldNode.(type) {
 			case *ast.Var:
 				// If the field is a var, we need to find the value of the var
 				// To do so, we get the stack where the var is used and search that stack for the var's definition

--- a/pkg/server/definition_test.go
+++ b/pkg/server/definition_test.go
@@ -419,7 +419,7 @@ func TestDefinition(t *testing.T) {
 		{
 			name:     "goto with overrides: clobber string",
 			filename: "testdata/goto-overrides.jsonnet",
-			position: protocol.Position{Line: 40, Character: 30},
+			position: protocol.Position{Line: 41, Character: 30},
 			results: []definitionResult{{
 				targetRange: protocol.Range{
 					Start: protocol.Position{Line: 24, Character: 4},
@@ -434,7 +434,7 @@ func TestDefinition(t *testing.T) {
 		{
 			name:     "goto with overrides: clobber nested string",
 			filename: "testdata/goto-overrides.jsonnet",
-			position: protocol.Position{Line: 41, Character: 44},
+			position: protocol.Position{Line: 42, Character: 44},
 			results: []definitionResult{{
 				targetRange: protocol.Range{
 					Start: protocol.Position{Line: 26, Character: 6},
@@ -449,7 +449,7 @@ func TestDefinition(t *testing.T) {
 		{
 			name:     "goto with overrides: clobber map",
 			filename: "testdata/goto-overrides.jsonnet",
-			position: protocol.Position{Line: 42, Character: 28},
+			position: protocol.Position{Line: 43, Character: 28},
 			results: []definitionResult{{
 				targetRange: protocol.Range{
 					Start: protocol.Position{Line: 28, Character: 4},
@@ -500,7 +500,7 @@ func TestDefinition(t *testing.T) {
 					targetFilename: "testdata/goto-overrides-base.jsonnet",
 					targetRange: protocol.Range{
 						Start: protocol.Position{Line: 19, Character: 2},
-						End:   protocol.Position{Line: 19, Character: 48},
+						End:   protocol.Position{Line: 19, Character: 94},
 					},
 					targetSelectionRange: protocol.Range{
 						Start: protocol.Position{Line: 19, Character: 2},
@@ -564,6 +564,17 @@ func TestDefinition(t *testing.T) {
 					targetSelectionRange: protocol.Range{
 						Start: protocol.Position{Line: 4, Character: 4},
 						End:   protocol.Position{Line: 4, Character: 11},
+					},
+				},
+				{
+					targetFilename: "testdata/goto-overrides-imported2.jsonnet",
+					targetRange: protocol.Range{
+						Start: protocol.Position{Line: 1, Character: 2},
+						End:   protocol.Position{Line: 3, Character: 3},
+					},
+					targetSelectionRange: protocol.Range{
+						Start: protocol.Position{Line: 1, Character: 2},
+						End:   protocol.Position{Line: 1, Character: 9},
 					},
 				},
 				{
@@ -660,6 +671,22 @@ func TestDefinition(t *testing.T) {
 				targetSelectionRange: protocol.Range{
 					Start: protocol.Position{Line: 2, Character: 4},
 					End:   protocol.Position{Line: 2, Character: 15},
+				},
+			}},
+		},
+		{
+			name:     "goto with overrides: string carried from second import",
+			filename: "testdata/goto-overrides.jsonnet",
+			position: protocol.Position{Line: 39, Character: 67},
+			results: []definitionResult{{
+				targetFilename: "testdata/goto-overrides-imported2.jsonnet",
+				targetRange: protocol.Range{
+					Start: protocol.Position{Line: 2, Character: 4},
+					End:   protocol.Position{Line: 2, Character: 30},
+				},
+				targetSelectionRange: protocol.Range{
+					Start: protocol.Position{Line: 2, Character: 4},
+					End:   protocol.Position{Line: 2, Character: 22},
 				},
 			}},
 		},

--- a/pkg/server/testdata/goto-overrides-base.jsonnet
+++ b/pkg/server/testdata/goto-overrides-base.jsonnet
@@ -17,5 +17,5 @@
   a+: extensionFromLocal,
 }
 + {
-  a+: (import 'goto-overrides-imported.jsonnet'),
+  a+: (import 'goto-overrides-imported.jsonnet') + (import 'goto-overrides-imported2.jsonnet'),
 }

--- a/pkg/server/testdata/goto-overrides-imported2.jsonnet
+++ b/pkg/server/testdata/goto-overrides-imported2.jsonnet
@@ -1,0 +1,5 @@
+{
+  nested1+: {
+    from_second_import: 'hey!',
+  },
+}

--- a/pkg/server/testdata/goto-overrides.jsonnet
+++ b/pkg/server/testdata/goto-overrides.jsonnet
@@ -37,6 +37,7 @@
   carried_nested_string: self.a.nested1.hello2,  // This should refer to the initial definition (map 3)
   carried_nested_string_from_local: self.a.nested1.from_local,  // This should refer to the definition specified in a local in the base file
   carried_nested_string_from_import: self.a.nested1.from_import,  // This should refer to the definition specified in an import in the base file
+  carried_nested_string_from_second_import: self.a.nested1.from_second_import,  // This should refer to the definition specified in an import in the base file
 
   clobbered_string: self.a.hello2,  // This should refer to the override only (map 4)
   clobbered_nested_string: self.a.nested1.hello,  // This should refer to the override only (map 4)


### PR DESCRIPTION
Whenever a binary operator was in the chain, it would make all fields to not be found further down the line
This supports find fields in constructs like this:
```
{
  my_field+: (import 'test') + (import 'test2')
}
```

Note: the tests are getting pretty intense. I'm planning a refactor once I've got the cases I want working. I'll probably set up some benchmarking as well, see if I can find some low-hanging fruits for performance improvements

This builds upon https://github.com/grafana/jsonnet-language-server/pull/30 and https://github.com/grafana/jsonnet-language-server/pull/31
Issue: #6