### PR TITLE
Definition: Do not fail the request when there's an error

### DIFF
--- a/pkg/server/definition_test.go
+++ b/pkg/server/definition_test.go
@@ -737,7 +737,7 @@ func TestDefinition(t *testing.T) {
 			server := NewServer("any", "test version", nil)
 			server.getVM = testGetVM
 			serverOpenTestFile(t, server, string(tc.filename))
-			response, err := server.definitionLink(context.Background(), params, false)
+			response, err := server.definitionLink(context.Background(), params)
 			require.NoError(t, err)
 
 			var expected []protocol.DefinitionLink
@@ -821,7 +821,7 @@ func TestDefinitionFail(t *testing.T) {
 			server := NewServer("any", "test version", nil)
 			server.getVM = testGetVM
 			serverOpenTestFile(t, server, tc.filename)
-			got, err := server.definitionLink(context.Background(), params, false)
+			got, err := server.definitionLink(context.Background(), params)
 
 			require.Error(t, err)
 			assert.Equal(t, tc.expected.Error(), err.Error())


### PR DESCRIPTION
Instead, just log the error. If we fail the request completely, the client (in my case vscode) goes crazy and may even kill the language server
However, it's a pretty normal scenario that the AST is not valid (when modifying jsonnet, for example)