### PR TITLE
Add benchmark test for "go to definition"

### DIFF
--- a/main.go
+++ b/main.go
@@ -103,7 +103,7 @@ func main() {
 	log.Infoln("Starting the language server")
 
 	ctx := context.Background()
-	stream := jsonrpc2.NewHeaderStream(utils.Stdio{})
+	stream := jsonrpc2.NewHeaderStream(utils.NewDefaultStdio())
 	conn := jsonrpc2.NewConn(stream)
 	client := protocol.ClientDispatcher(conn)
 

--- a/pkg/server/definition_test.go
+++ b/pkg/server/definition_test.go
@@ -19,711 +19,714 @@ type definitionResult struct {
 	targetSelectionRange protocol.Range
 }
 
-func TestDefinition(t *testing.T) {
-	testCases := []struct {
-		name     string
-		filename string
-		position protocol.Position
+type definitionTestCase struct {
+	name     string
+	filename string
+	position protocol.Position
 
-		results []definitionResult
-	}{
-		{
-			name:     "test goto definition for var myvar",
-			filename: "./testdata/test_goto_definition.jsonnet",
-			position: protocol.Position{Line: 5, Character: 19},
-			results: []definitionResult{{
+	results []definitionResult
+}
+
+var definitionTestCases = []definitionTestCase{
+	{
+		name:     "test goto definition for var myvar",
+		filename: "./testdata/test_goto_definition.jsonnet",
+		position: protocol.Position{Line: 5, Character: 19},
+		results: []definitionResult{{
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 0, Character: 6},
+				End:   protocol.Position{Line: 0, Character: 15},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 0, Character: 6},
+				End:   protocol.Position{Line: 0, Character: 11},
+			},
+		}},
+	},
+	{
+		name:     "test goto definition on function helper",
+		filename: "./testdata/test_goto_definition.jsonnet",
+		position: protocol.Position{Line: 7, Character: 8},
+		results: []definitionResult{{
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 1, Character: 6},
+				End:   protocol.Position{Line: 1, Character: 23},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 1, Character: 6},
+				End:   protocol.Position{Line: 1, Character: 12},
+			},
+		}},
+	},
+	{
+		name:     "test goto inner definition",
+		filename: "./testdata/test_goto_definition_multi_locals.jsonnet",
+		position: protocol.Position{Line: 6, Character: 9},
+		results: []definitionResult{{
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 4, Character: 8},
+				End:   protocol.Position{Line: 4, Character: 26},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 4, Character: 8},
+				End:   protocol.Position{Line: 4, Character: 16},
+			},
+		}},
+	},
+	{
+		name:     "test goto super index",
+		filename: "./testdata/test_combined_object.jsonnet",
+		position: protocol.Position{Line: 5, Character: 11},
+		results: []definitionResult{{
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 1, Character: 2},
+				End:   protocol.Position{Line: 3, Character: 3},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 1, Character: 2},
+				End:   protocol.Position{Line: 1, Character: 3},
+			},
+		}},
+	},
+	{
+		name:     "test goto super nested",
+		filename: "./testdata/test_combined_object.jsonnet",
+		position: protocol.Position{Line: 5, Character: 13},
+		results: []definitionResult{{
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 2, Character: 4},
+				End:   protocol.Position{Line: 2, Character: 18},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 2, Character: 4},
+				End:   protocol.Position{Line: 2, Character: 5},
+			},
+		}},
+	},
+	{
+		name:     "test goto self object field function",
+		filename: "./testdata/test_basic_lib.libsonnet",
+		position: protocol.Position{Line: 4, Character: 17},
+		results: []definitionResult{{
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 1, Character: 2},
+				End:   protocol.Position{Line: 3, Character: 16},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 1, Character: 2},
+				End:   protocol.Position{Line: 1, Character: 7},
+			},
+		}},
+	},
+	{
+		name:     "test goto super object field local defined obj 'foo'",
+		filename: "./testdata/oo-contrived.jsonnet",
+		position: protocol.Position{Line: 12, Character: 17},
+		results: []definitionResult{{
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 1, Character: 2},
+				End:   protocol.Position{Line: 1, Character: 8},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 1, Character: 2},
+				End:   protocol.Position{Line: 1, Character: 5},
+			},
+		}},
+	},
+	{
+		name:     "test goto super object field local defined obj 'g'",
+		filename: "./testdata/oo-contrived.jsonnet",
+		position: protocol.Position{Line: 13, Character: 17},
+		results: []definitionResult{{
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 2, Character: 2},
+				End:   protocol.Position{Line: 2, Character: 19},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 2, Character: 2},
+				End:   protocol.Position{Line: 2, Character: 3},
+			},
+		}},
+	},
+	{
+		name:     "test goto local var from other local var",
+		filename: "./testdata/oo-contrived.jsonnet",
+		position: protocol.Position{Line: 6, Character: 9},
+		results: []definitionResult{{
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 0, Character: 6},
+				End:   protocol.Position{Line: 3, Character: 1},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 0, Character: 6},
+				End:   protocol.Position{Line: 0, Character: 10},
+			},
+		}},
+	},
+	{
+		name:     "test goto local obj field from 'self.attr' from other obj",
+		filename: "./testdata/goto-indexes.jsonnet",
+		position: protocol.Position{Line: 9, Character: 16},
+		results: []definitionResult{{
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 2, Character: 4},
+				End:   protocol.Position{Line: 2, Character: 19},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 2, Character: 4},
+				End:   protocol.Position{Line: 2, Character: 7},
+			},
+		}},
+	},
+	{
+		name:     "test goto local object 'obj' via obj index 'obj.foo'",
+		filename: "./testdata/goto-indexes.jsonnet",
+		position: protocol.Position{Line: 8, Character: 13},
+		results: []definitionResult{{
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 1, Character: 2},
+				End:   protocol.Position{Line: 3, Character: 3},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 1, Character: 2},
+				End:   protocol.Position{Line: 1, Character: 5},
+			},
+		}},
+	},
+	{
+		name:     "test goto imported file",
+		filename: "./testdata/goto-imported-file.jsonnet",
+		position: protocol.Position{Line: 0, Character: 22},
+		results: []definitionResult{{
+			targetFilename: "testdata/goto-basic-object.jsonnet",
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 0, Character: 0},
+				End:   protocol.Position{Line: 0, Character: 0},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 0, Character: 0},
+				End:   protocol.Position{Line: 0, Character: 0},
+			},
+		}},
+	},
+	{
+		name:     "test goto imported file at lhs index",
+		filename: "./testdata/goto-imported-file.jsonnet",
+		position: protocol.Position{Line: 3, Character: 16},
+		results: []definitionResult{{
+			targetFilename: "testdata/goto-basic-object.jsonnet",
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 3, Character: 2},
+				End:   protocol.Position{Line: 3, Character: 12},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 3, Character: 2},
+				End:   protocol.Position{Line: 3, Character: 5},
+			},
+		}},
+	},
+	{
+		name:     "test goto imported file at rhs index",
+		filename: "./testdata/goto-imported-file.jsonnet",
+		position: protocol.Position{Line: 4, Character: 16},
+		results: []definitionResult{{
+			targetFilename: "testdata/goto-basic-object.jsonnet",
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 5, Character: 2},
+				End:   protocol.Position{Line: 5, Character: 12},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 5, Character: 2},
+				End:   protocol.Position{Line: 5, Character: 5},
+			},
+		}},
+	},
+	{
+		name:     "goto import index",
+		filename: "testdata/goto-import-attribute.jsonnet",
+		position: protocol.Position{Line: 0, Character: 48},
+		results: []definitionResult{{
+			targetFilename: "testdata/goto-basic-object.jsonnet",
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 5, Character: 2},
+				End:   protocol.Position{Line: 5, Character: 12},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 5, Character: 2},
+				End:   protocol.Position{Line: 5, Character: 5},
+			},
+		}},
+	},
+	{
+		name:     "goto attribute of nested import",
+		filename: "testdata/goto-nested-imported-file.jsonnet",
+		position: protocol.Position{Line: 2, Character: 13},
+		results: []definitionResult{{
+			targetFilename: "testdata/goto-basic-object.jsonnet",
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 3, Character: 2},
+				End:   protocol.Position{Line: 3, Character: 12},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 3, Character: 2},
+				End:   protocol.Position{Line: 3, Character: 5},
+			},
+		}},
+	},
+	{
+		name:     "goto dollar attribute",
+		filename: "testdata/goto-dollar-simple.jsonnet",
+		position: protocol.Position{Line: 7, Character: 17},
+		results: []definitionResult{{
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 1, Character: 2},
+				End:   protocol.Position{Line: 3, Character: 3},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 1, Character: 2},
+				End:   protocol.Position{Line: 1, Character: 11},
+			},
+		}},
+	},
+	{
+		name:     "goto dollar sub attribute",
+		filename: "testdata/goto-dollar-simple.jsonnet",
+		position: protocol.Position{Line: 8, Character: 28},
+		results: []definitionResult{{
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 2, Character: 4},
+				End:   protocol.Position{Line: 2, Character: 15},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 2, Character: 4},
+				End:   protocol.Position{Line: 2, Character: 7},
+			},
+		}},
+	},
+	{
+		name:     "goto dollar doesn't follow to imports",
+		filename: "testdata/goto-dollar-no-follow.jsonnet",
+		position: protocol.Position{Line: 7, Character: 13},
+		results: []definitionResult{{
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 3, Character: 2},
+				End:   protocol.Position{Line: 3, Character: 30},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 3, Character: 2},
+				End:   protocol.Position{Line: 3, Character: 6},
+			},
+		}},
+	},
+	{
+		name:     "goto attribute of nested import no object intermediary",
+		filename: "testdata/goto-nested-import-file-no-inter-obj.jsonnet",
+		position: protocol.Position{Line: 2, Character: 13},
+		results: []definitionResult{{
+			targetFilename: "testdata/goto-basic-object.jsonnet",
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 3, Character: 2},
+				End:   protocol.Position{Line: 3, Character: 12},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 3, Character: 2},
+				End:   protocol.Position{Line: 3, Character: 5},
+			},
+		}},
+	},
+	{
+		name:     "goto self in import in binary",
+		filename: "testdata/goto-self-within-binary.jsonnet",
+		position: protocol.Position{Line: 4, Character: 13},
+		results: []definitionResult{{
+			targetFilename: "testdata/goto-basic-object.jsonnet",
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 3, Character: 2},
+				End:   protocol.Position{Line: 3, Character: 12},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 3, Character: 2},
+				End:   protocol.Position{Line: 3, Character: 5},
+			},
+		}},
+	},
+	{
+		name:     "goto self attribute from local",
+		filename: "testdata/goto-self-in-local.jsonnet",
+		position: protocol.Position{Line: 3, Character: 23},
+		results: []definitionResult{{
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 2, Character: 2},
+				End:   protocol.Position{Line: 2, Character: 21},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 2, Character: 2},
+				End:   protocol.Position{Line: 2, Character: 12},
+			},
+		}},
+	},
+	{
+		name:     "goto function parameter from inside function",
+		filename: "testdata/goto-functions.libsonnet",
+		position: protocol.Position{Line: 7, Character: 10},
+		results: []definitionResult{{
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 6, Character: 10},
+				End:   protocol.Position{Line: 6, Character: 14},
+			},
+		}},
+	},
+	{
+		name:     "goto local func param",
+		filename: "testdata/goto-local-function.libsonnet",
+		position: protocol.Position{Line: 2, Character: 25},
+		results: []definitionResult{{
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 0, Character: 11},
+				End:   protocol.Position{Line: 0, Character: 12},
+			},
+		}},
+	},
+	{
+		name:     "goto self complex scope 1",
+		filename: "testdata/goto-self-complex-scoping.jsonnet",
+		position: protocol.Position{Line: 10, Character: 15},
+		results: []definitionResult{{
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 6, Character: 2},
+				End:   protocol.Position{Line: 8, Character: 3},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 6, Character: 2},
+				End:   protocol.Position{Line: 6, Character: 6},
+			},
+		}},
+	},
+	{
+		name:     "goto self complex scope 2",
+		filename: "testdata/goto-self-complex-scoping.jsonnet",
+		position: protocol.Position{Line: 11, Character: 19},
+		results: []definitionResult{{
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 7, Character: 4},
+				End:   protocol.Position{Line: 7, Character: 18},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 7, Character: 4},
+				End:   protocol.Position{Line: 7, Character: 9},
+			},
+		}},
+	},
+	{
+		name:     "goto with overrides: clobber string",
+		filename: "testdata/goto-overrides.jsonnet",
+		position: protocol.Position{Line: 41, Character: 30},
+		results: []definitionResult{{
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 24, Character: 4},
+				End:   protocol.Position{Line: 24, Character: 23},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 24, Character: 4},
+				End:   protocol.Position{Line: 24, Character: 10},
+			},
+		}},
+	},
+	{
+		name:     "goto with overrides: clobber nested string",
+		filename: "testdata/goto-overrides.jsonnet",
+		position: protocol.Position{Line: 42, Character: 44},
+		results: []definitionResult{{
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 26, Character: 6},
+				End:   protocol.Position{Line: 26, Character: 24},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 26, Character: 6},
+				End:   protocol.Position{Line: 26, Character: 11},
+			},
+		}},
+	},
+	{
+		name:     "goto with overrides: clobber map",
+		filename: "testdata/goto-overrides.jsonnet",
+		position: protocol.Position{Line: 43, Character: 28},
+		results: []definitionResult{{
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 28, Character: 4},
+				End:   protocol.Position{Line: 28, Character: 15},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 28, Character: 4},
+				End:   protocol.Position{Line: 28, Character: 11},
+			},
+		}},
+	},
+	{
+		name:     "goto with overrides: map (multiple definitions)",
+		filename: "testdata/goto-overrides.jsonnet",
+		position: protocol.Position{Line: 32, Character: 22},
+		results: []definitionResult{
+			{
 				targetRange: protocol.Range{
-					Start: protocol.Position{Line: 0, Character: 6},
-					End:   protocol.Position{Line: 0, Character: 15},
+					Start: protocol.Position{Line: 23, Character: 2},
+					End:   protocol.Position{Line: 29, Character: 3},
 				},
 				targetSelectionRange: protocol.Range{
-					Start: protocol.Position{Line: 0, Character: 6},
-					End:   protocol.Position{Line: 0, Character: 11},
+					Start: protocol.Position{Line: 23, Character: 2},
+					End:   protocol.Position{Line: 23, Character: 3},
 				},
-			}},
-		},
-		{
-			name:     "test goto definition on function helper",
-			filename: "./testdata/test_goto_definition.jsonnet",
-			position: protocol.Position{Line: 7, Character: 8},
-			results: []definitionResult{{
+			},
+			{
 				targetRange: protocol.Range{
-					Start: protocol.Position{Line: 1, Character: 6},
-					End:   protocol.Position{Line: 1, Character: 23},
+					Start: protocol.Position{Line: 14, Character: 2},
+					End:   protocol.Position{Line: 19, Character: 3},
 				},
 				targetSelectionRange: protocol.Range{
-					Start: protocol.Position{Line: 1, Character: 6},
-					End:   protocol.Position{Line: 1, Character: 12},
+					Start: protocol.Position{Line: 14, Character: 2},
+					End:   protocol.Position{Line: 14, Character: 3},
 				},
-			}},
-		},
-		{
-			name:     "test goto inner definition",
-			filename: "./testdata/test_goto_definition_multi_locals.jsonnet",
-			position: protocol.Position{Line: 6, Character: 9},
-			results: []definitionResult{{
-				targetRange: protocol.Range{
-					Start: protocol.Position{Line: 4, Character: 8},
-					End:   protocol.Position{Line: 4, Character: 26},
-				},
-				targetSelectionRange: protocol.Range{
-					Start: protocol.Position{Line: 4, Character: 8},
-					End:   protocol.Position{Line: 4, Character: 16},
-				},
-			}},
-		},
-		{
-			name:     "test goto super index",
-			filename: "./testdata/test_combined_object.jsonnet",
-			position: protocol.Position{Line: 5, Character: 11},
-			results: []definitionResult{{
-				targetRange: protocol.Range{
-					Start: protocol.Position{Line: 1, Character: 2},
-					End:   protocol.Position{Line: 3, Character: 3},
-				},
-				targetSelectionRange: protocol.Range{
-					Start: protocol.Position{Line: 1, Character: 2},
-					End:   protocol.Position{Line: 1, Character: 3},
-				},
-			}},
-		},
-		{
-			name:     "test goto super nested",
-			filename: "./testdata/test_combined_object.jsonnet",
-			position: protocol.Position{Line: 5, Character: 13},
-			results: []definitionResult{{
-				targetRange: protocol.Range{
-					Start: protocol.Position{Line: 2, Character: 4},
-					End:   protocol.Position{Line: 2, Character: 18},
-				},
-				targetSelectionRange: protocol.Range{
-					Start: protocol.Position{Line: 2, Character: 4},
-					End:   protocol.Position{Line: 2, Character: 5},
-				},
-			}},
-		},
-		{
-			name:     "test goto self object field function",
-			filename: "./testdata/test_basic_lib.libsonnet",
-			position: protocol.Position{Line: 4, Character: 17},
-			results: []definitionResult{{
-				targetRange: protocol.Range{
-					Start: protocol.Position{Line: 1, Character: 2},
-					End:   protocol.Position{Line: 3, Character: 16},
-				},
-				targetSelectionRange: protocol.Range{
-					Start: protocol.Position{Line: 1, Character: 2},
-					End:   protocol.Position{Line: 1, Character: 7},
-				},
-			}},
-		},
-		{
-			name:     "test goto super object field local defined obj 'foo'",
-			filename: "./testdata/oo-contrived.jsonnet",
-			position: protocol.Position{Line: 12, Character: 17},
-			results: []definitionResult{{
-				targetRange: protocol.Range{
-					Start: protocol.Position{Line: 1, Character: 2},
-					End:   protocol.Position{Line: 1, Character: 8},
-				},
-				targetSelectionRange: protocol.Range{
-					Start: protocol.Position{Line: 1, Character: 2},
-					End:   protocol.Position{Line: 1, Character: 5},
-				},
-			}},
-		},
-		{
-			name:     "test goto super object field local defined obj 'g'",
-			filename: "./testdata/oo-contrived.jsonnet",
-			position: protocol.Position{Line: 13, Character: 17},
-			results: []definitionResult{{
+			},
+			{
 				targetRange: protocol.Range{
 					Start: protocol.Position{Line: 2, Character: 2},
-					End:   protocol.Position{Line: 2, Character: 19},
+					End:   protocol.Position{Line: 10, Character: 3},
 				},
 				targetSelectionRange: protocol.Range{
 					Start: protocol.Position{Line: 2, Character: 2},
 					End:   protocol.Position{Line: 2, Character: 3},
 				},
-			}},
-		},
-		{
-			name:     "test goto local var from other local var",
-			filename: "./testdata/oo-contrived.jsonnet",
-			position: protocol.Position{Line: 6, Character: 9},
-			results: []definitionResult{{
-				targetRange: protocol.Range{
-					Start: protocol.Position{Line: 0, Character: 6},
-					End:   protocol.Position{Line: 3, Character: 1},
-				},
-				targetSelectionRange: protocol.Range{
-					Start: protocol.Position{Line: 0, Character: 6},
-					End:   protocol.Position{Line: 0, Character: 10},
-				},
-			}},
-		},
-		{
-			name:     "test goto local obj field from 'self.attr' from other obj",
-			filename: "./testdata/goto-indexes.jsonnet",
-			position: protocol.Position{Line: 9, Character: 16},
-			results: []definitionResult{{
-				targetRange: protocol.Range{
-					Start: protocol.Position{Line: 2, Character: 4},
-					End:   protocol.Position{Line: 2, Character: 19},
-				},
-				targetSelectionRange: protocol.Range{
-					Start: protocol.Position{Line: 2, Character: 4},
-					End:   protocol.Position{Line: 2, Character: 7},
-				},
-			}},
-		},
-		{
-			name:     "test goto local object 'obj' via obj index 'obj.foo'",
-			filename: "./testdata/goto-indexes.jsonnet",
-			position: protocol.Position{Line: 8, Character: 13},
-			results: []definitionResult{{
-				targetRange: protocol.Range{
-					Start: protocol.Position{Line: 1, Character: 2},
-					End:   protocol.Position{Line: 3, Character: 3},
-				},
-				targetSelectionRange: protocol.Range{
-					Start: protocol.Position{Line: 1, Character: 2},
-					End:   protocol.Position{Line: 1, Character: 5},
-				},
-			}},
-		},
-		{
-			name:     "test goto imported file",
-			filename: "./testdata/goto-imported-file.jsonnet",
-			position: protocol.Position{Line: 0, Character: 22},
-			results: []definitionResult{{
-				targetFilename: "testdata/goto-basic-object.jsonnet",
-				targetRange: protocol.Range{
-					Start: protocol.Position{Line: 0, Character: 0},
-					End:   protocol.Position{Line: 0, Character: 0},
-				},
-				targetSelectionRange: protocol.Range{
-					Start: protocol.Position{Line: 0, Character: 0},
-					End:   protocol.Position{Line: 0, Character: 0},
-				},
-			}},
-		},
-		{
-			name:     "test goto imported file at lhs index",
-			filename: "./testdata/goto-imported-file.jsonnet",
-			position: protocol.Position{Line: 3, Character: 16},
-			results: []definitionResult{{
-				targetFilename: "testdata/goto-basic-object.jsonnet",
-				targetRange: protocol.Range{
-					Start: protocol.Position{Line: 3, Character: 2},
-					End:   protocol.Position{Line: 3, Character: 12},
-				},
-				targetSelectionRange: protocol.Range{
-					Start: protocol.Position{Line: 3, Character: 2},
-					End:   protocol.Position{Line: 3, Character: 5},
-				},
-			}},
-		},
-		{
-			name:     "test goto imported file at rhs index",
-			filename: "./testdata/goto-imported-file.jsonnet",
-			position: protocol.Position{Line: 4, Character: 16},
-			results: []definitionResult{{
-				targetFilename: "testdata/goto-basic-object.jsonnet",
-				targetRange: protocol.Range{
-					Start: protocol.Position{Line: 5, Character: 2},
-					End:   protocol.Position{Line: 5, Character: 12},
-				},
-				targetSelectionRange: protocol.Range{
-					Start: protocol.Position{Line: 5, Character: 2},
-					End:   protocol.Position{Line: 5, Character: 5},
-				},
-			}},
-		},
-		{
-			name:     "goto import index",
-			filename: "testdata/goto-import-attribute.jsonnet",
-			position: protocol.Position{Line: 0, Character: 48},
-			results: []definitionResult{{
-				targetFilename: "testdata/goto-basic-object.jsonnet",
-				targetRange: protocol.Range{
-					Start: protocol.Position{Line: 5, Character: 2},
-					End:   protocol.Position{Line: 5, Character: 12},
-				},
-				targetSelectionRange: protocol.Range{
-					Start: protocol.Position{Line: 5, Character: 2},
-					End:   protocol.Position{Line: 5, Character: 5},
-				},
-			}},
-		},
-		{
-			name:     "goto attribute of nested import",
-			filename: "testdata/goto-nested-imported-file.jsonnet",
-			position: protocol.Position{Line: 2, Character: 13},
-			results: []definitionResult{{
-				targetFilename: "testdata/goto-basic-object.jsonnet",
-				targetRange: protocol.Range{
-					Start: protocol.Position{Line: 3, Character: 2},
-					End:   protocol.Position{Line: 3, Character: 12},
-				},
-				targetSelectionRange: protocol.Range{
-					Start: protocol.Position{Line: 3, Character: 2},
-					End:   protocol.Position{Line: 3, Character: 5},
-				},
-			}},
-		},
-		{
-			name:     "goto dollar attribute",
-			filename: "testdata/goto-dollar-simple.jsonnet",
-			position: protocol.Position{Line: 7, Character: 17},
-			results: []definitionResult{{
-				targetRange: protocol.Range{
-					Start: protocol.Position{Line: 1, Character: 2},
-					End:   protocol.Position{Line: 3, Character: 3},
-				},
-				targetSelectionRange: protocol.Range{
-					Start: protocol.Position{Line: 1, Character: 2},
-					End:   protocol.Position{Line: 1, Character: 11},
-				},
-			}},
-		},
-		{
-			name:     "goto dollar sub attribute",
-			filename: "testdata/goto-dollar-simple.jsonnet",
-			position: protocol.Position{Line: 8, Character: 28},
-			results: []definitionResult{{
-				targetRange: protocol.Range{
-					Start: protocol.Position{Line: 2, Character: 4},
-					End:   protocol.Position{Line: 2, Character: 15},
-				},
-				targetSelectionRange: protocol.Range{
-					Start: protocol.Position{Line: 2, Character: 4},
-					End:   protocol.Position{Line: 2, Character: 7},
-				},
-			}},
-		},
-		{
-			name:     "goto dollar doesn't follow to imports",
-			filename: "testdata/goto-dollar-no-follow.jsonnet",
-			position: protocol.Position{Line: 7, Character: 13},
-			results: []definitionResult{{
-				targetRange: protocol.Range{
-					Start: protocol.Position{Line: 3, Character: 2},
-					End:   protocol.Position{Line: 3, Character: 30},
-				},
-				targetSelectionRange: protocol.Range{
-					Start: protocol.Position{Line: 3, Character: 2},
-					End:   protocol.Position{Line: 3, Character: 6},
-				},
-			}},
-		},
-		{
-			name:     "goto attribute of nested import no object intermediary",
-			filename: "testdata/goto-nested-import-file-no-inter-obj.jsonnet",
-			position: protocol.Position{Line: 2, Character: 13},
-			results: []definitionResult{{
-				targetFilename: "testdata/goto-basic-object.jsonnet",
-				targetRange: protocol.Range{
-					Start: protocol.Position{Line: 3, Character: 2},
-					End:   protocol.Position{Line: 3, Character: 12},
-				},
-				targetSelectionRange: protocol.Range{
-					Start: protocol.Position{Line: 3, Character: 2},
-					End:   protocol.Position{Line: 3, Character: 5},
-				},
-			}},
-		},
-		{
-			name:     "goto self in import in binary",
-			filename: "testdata/goto-self-within-binary.jsonnet",
-			position: protocol.Position{Line: 4, Character: 13},
-			results: []definitionResult{{
-				targetFilename: "testdata/goto-basic-object.jsonnet",
-				targetRange: protocol.Range{
-					Start: protocol.Position{Line: 3, Character: 2},
-					End:   protocol.Position{Line: 3, Character: 12},
-				},
-				targetSelectionRange: protocol.Range{
-					Start: protocol.Position{Line: 3, Character: 2},
-					End:   protocol.Position{Line: 3, Character: 5},
-				},
-			}},
-		},
-		{
-			name:     "goto self attribute from local",
-			filename: "testdata/goto-self-in-local.jsonnet",
-			position: protocol.Position{Line: 3, Character: 23},
-			results: []definitionResult{{
-				targetRange: protocol.Range{
-					Start: protocol.Position{Line: 2, Character: 2},
-					End:   protocol.Position{Line: 2, Character: 21},
-				},
-				targetSelectionRange: protocol.Range{
-					Start: protocol.Position{Line: 2, Character: 2},
-					End:   protocol.Position{Line: 2, Character: 12},
-				},
-			}},
-		},
-		{
-			name:     "goto function parameter from inside function",
-			filename: "testdata/goto-functions.libsonnet",
-			position: protocol.Position{Line: 7, Character: 10},
-			results: []definitionResult{{
-				targetRange: protocol.Range{
-					Start: protocol.Position{Line: 6, Character: 10},
-					End:   protocol.Position{Line: 6, Character: 14},
-				},
-			}},
-		},
-		{
-			name:     "goto local func param",
-			filename: "testdata/goto-local-function.libsonnet",
-			position: protocol.Position{Line: 2, Character: 25},
-			results: []definitionResult{{
-				targetRange: protocol.Range{
-					Start: protocol.Position{Line: 0, Character: 11},
-					End:   protocol.Position{Line: 0, Character: 12},
-				},
-			}},
-		},
-		{
-			name:     "goto self complex scope 1",
-			filename: "testdata/goto-self-complex-scoping.jsonnet",
-			position: protocol.Position{Line: 10, Character: 15},
-			results: []definitionResult{{
-				targetRange: protocol.Range{
-					Start: protocol.Position{Line: 6, Character: 2},
-					End:   protocol.Position{Line: 8, Character: 3},
-				},
-				targetSelectionRange: protocol.Range{
-					Start: protocol.Position{Line: 6, Character: 2},
-					End:   protocol.Position{Line: 6, Character: 6},
-				},
-			}},
-		},
-		{
-			name:     "goto self complex scope 2",
-			filename: "testdata/goto-self-complex-scoping.jsonnet",
-			position: protocol.Position{Line: 11, Character: 19},
-			results: []definitionResult{{
-				targetRange: protocol.Range{
-					Start: protocol.Position{Line: 7, Character: 4},
-					End:   protocol.Position{Line: 7, Character: 18},
-				},
-				targetSelectionRange: protocol.Range{
-					Start: protocol.Position{Line: 7, Character: 4},
-					End:   protocol.Position{Line: 7, Character: 9},
-				},
-			}},
-		},
-		{
-			name:     "goto with overrides: clobber string",
-			filename: "testdata/goto-overrides.jsonnet",
-			position: protocol.Position{Line: 41, Character: 30},
-			results: []definitionResult{{
-				targetRange: protocol.Range{
-					Start: protocol.Position{Line: 24, Character: 4},
-					End:   protocol.Position{Line: 24, Character: 23},
-				},
-				targetSelectionRange: protocol.Range{
-					Start: protocol.Position{Line: 24, Character: 4},
-					End:   protocol.Position{Line: 24, Character: 10},
-				},
-			}},
-		},
-		{
-			name:     "goto with overrides: clobber nested string",
-			filename: "testdata/goto-overrides.jsonnet",
-			position: protocol.Position{Line: 42, Character: 44},
-			results: []definitionResult{{
-				targetRange: protocol.Range{
-					Start: protocol.Position{Line: 26, Character: 6},
-					End:   protocol.Position{Line: 26, Character: 24},
-				},
-				targetSelectionRange: protocol.Range{
-					Start: protocol.Position{Line: 26, Character: 6},
-					End:   protocol.Position{Line: 26, Character: 11},
-				},
-			}},
-		},
-		{
-			name:     "goto with overrides: clobber map",
-			filename: "testdata/goto-overrides.jsonnet",
-			position: protocol.Position{Line: 43, Character: 28},
-			results: []definitionResult{{
-				targetRange: protocol.Range{
-					Start: protocol.Position{Line: 28, Character: 4},
-					End:   protocol.Position{Line: 28, Character: 15},
-				},
-				targetSelectionRange: protocol.Range{
-					Start: protocol.Position{Line: 28, Character: 4},
-					End:   protocol.Position{Line: 28, Character: 11},
-				},
-			}},
-		},
-		{
-			name:     "goto with overrides: map (multiple definitions)",
-			filename: "testdata/goto-overrides.jsonnet",
-			position: protocol.Position{Line: 32, Character: 22},
-			results: []definitionResult{
-				{
-					targetRange: protocol.Range{
-						Start: protocol.Position{Line: 23, Character: 2},
-						End:   protocol.Position{Line: 29, Character: 3},
-					},
-					targetSelectionRange: protocol.Range{
-						Start: protocol.Position{Line: 23, Character: 2},
-						End:   protocol.Position{Line: 23, Character: 3},
-					},
-				},
-				{
-					targetRange: protocol.Range{
-						Start: protocol.Position{Line: 14, Character: 2},
-						End:   protocol.Position{Line: 19, Character: 3},
-					},
-					targetSelectionRange: protocol.Range{
-						Start: protocol.Position{Line: 14, Character: 2},
-						End:   protocol.Position{Line: 14, Character: 3},
-					},
-				},
-				{
-					targetRange: protocol.Range{
-						Start: protocol.Position{Line: 2, Character: 2},
-						End:   protocol.Position{Line: 10, Character: 3},
-					},
-					targetSelectionRange: protocol.Range{
-						Start: protocol.Position{Line: 2, Character: 2},
-						End:   protocol.Position{Line: 2, Character: 3},
-					},
-				},
-				{
-					targetFilename: "testdata/goto-overrides-base.jsonnet",
-					targetRange: protocol.Range{
-						Start: protocol.Position{Line: 19, Character: 2},
-						End:   protocol.Position{Line: 19, Character: 94},
-					},
-					targetSelectionRange: protocol.Range{
-						Start: protocol.Position{Line: 19, Character: 2},
-						End:   protocol.Position{Line: 19, Character: 3},
-					},
-				},
-				{
-					targetFilename: "testdata/goto-overrides-base.jsonnet",
-					targetRange: protocol.Range{
-						Start: protocol.Position{Line: 16, Character: 2},
-						End:   protocol.Position{Line: 16, Character: 24},
-					},
-					targetSelectionRange: protocol.Range{
-						Start: protocol.Position{Line: 16, Character: 2},
-						End:   protocol.Position{Line: 16, Character: 3},
-					},
-				},
-				{
-					targetFilename: "testdata/goto-overrides-base.jsonnet",
-					targetRange: protocol.Range{
-						Start: protocol.Position{Line: 1, Character: 2},
-						End:   protocol.Position{Line: 7, Character: 3},
-					},
-					targetSelectionRange: protocol.Range{
-						Start: protocol.Position{Line: 1, Character: 2},
-						End:   protocol.Position{Line: 1, Character: 3},
-					},
-				},
 			},
-		},
-		{
-			name:     "goto with overrides: nested map (multiple definitions)",
-			filename: "testdata/goto-overrides.jsonnet",
-			position: protocol.Position{Line: 33, Character: 34},
-			results: []definitionResult{
-				{
-					targetRange: protocol.Range{
-						Start: protocol.Position{Line: 25, Character: 4},
-						End:   protocol.Position{Line: 27, Character: 5},
-					},
-					targetSelectionRange: protocol.Range{
-						Start: protocol.Position{Line: 25, Character: 4},
-						End:   protocol.Position{Line: 25, Character: 11},
-					},
-				},
-				{
-					targetRange: protocol.Range{
-						Start: protocol.Position{Line: 16, Character: 4},
-						End:   protocol.Position{Line: 18, Character: 5},
-					},
-					targetSelectionRange: protocol.Range{
-						Start: protocol.Position{Line: 16, Character: 4},
-						End:   protocol.Position{Line: 16, Character: 11},
-					},
-				},
-				{
-					targetRange: protocol.Range{
-						Start: protocol.Position{Line: 4, Character: 4},
-						End:   protocol.Position{Line: 6, Character: 5},
-					},
-					targetSelectionRange: protocol.Range{
-						Start: protocol.Position{Line: 4, Character: 4},
-						End:   protocol.Position{Line: 4, Character: 11},
-					},
-				},
-				{
-					targetFilename: "testdata/goto-overrides-imported2.jsonnet",
-					targetRange: protocol.Range{
-						Start: protocol.Position{Line: 1, Character: 2},
-						End:   protocol.Position{Line: 3, Character: 3},
-					},
-					targetSelectionRange: protocol.Range{
-						Start: protocol.Position{Line: 1, Character: 2},
-						End:   protocol.Position{Line: 1, Character: 9},
-					},
-				},
-				{
-					targetFilename: "testdata/goto-overrides-imported.jsonnet",
-					targetRange: protocol.Range{
-						Start: protocol.Position{Line: 1, Character: 2},
-						End:   protocol.Position{Line: 3, Character: 3},
-					},
-					targetSelectionRange: protocol.Range{
-						Start: protocol.Position{Line: 1, Character: 2},
-						End:   protocol.Position{Line: 1, Character: 9},
-					},
-				},
-				{
-					targetFilename: "testdata/goto-overrides-base.jsonnet",
-					targetRange: protocol.Range{
-						Start: protocol.Position{Line: 12, Character: 4},
-						End:   protocol.Position{Line: 14, Character: 5},
-					},
-					targetSelectionRange: protocol.Range{
-						Start: protocol.Position{Line: 12, Character: 4},
-						End:   protocol.Position{Line: 12, Character: 11},
-					},
-				},
-				{
-					targetFilename: "testdata/goto-overrides-base.jsonnet",
-					targetRange: protocol.Range{
-						Start: protocol.Position{Line: 3, Character: 4},
-						End:   protocol.Position{Line: 5, Character: 5},
-					},
-					targetSelectionRange: protocol.Range{
-						Start: protocol.Position{Line: 3, Character: 4},
-						End:   protocol.Position{Line: 3, Character: 11},
-					},
-				},
-			},
-		},
-		{
-			name:     "goto with overrides: string carried from super",
-			filename: "testdata/goto-overrides.jsonnet",
-			position: protocol.Position{Line: 35, Character: 27},
-			results: []definitionResult{{
-				targetRange: protocol.Range{
-					Start: protocol.Position{Line: 3, Character: 4},
-					End:   protocol.Position{Line: 3, Character: 18},
-				},
-				targetSelectionRange: protocol.Range{
-					Start: protocol.Position{Line: 3, Character: 4},
-					End:   protocol.Position{Line: 3, Character: 9},
-				},
-			}},
-		},
-		{
-			name:     "goto with overrides: nested string carried from super",
-			filename: "testdata/goto-overrides.jsonnet",
-			position: protocol.Position{Line: 36, Character: 44},
-			results: []definitionResult{{
-				targetRange: protocol.Range{
-					Start: protocol.Position{Line: 17, Character: 6},
-					End:   protocol.Position{Line: 17, Character: 22},
-				},
-				targetSelectionRange: protocol.Range{
-					Start: protocol.Position{Line: 17, Character: 6},
-					End:   protocol.Position{Line: 17, Character: 12},
-				},
-			}},
-		},
-		{
-			name:     "goto with overrides: string carried from local",
-			filename: "testdata/goto-overrides.jsonnet",
-			position: protocol.Position{Line: 37, Character: 57},
-			results: []definitionResult{{
+			{
 				targetFilename: "testdata/goto-overrides-base.jsonnet",
 				targetRange: protocol.Range{
-					Start: protocol.Position{Line: 13, Character: 6},
-					End:   protocol.Position{Line: 13, Character: 24},
+					Start: protocol.Position{Line: 19, Character: 2},
+					End:   protocol.Position{Line: 19, Character: 94},
 				},
 				targetSelectionRange: protocol.Range{
-					Start: protocol.Position{Line: 13, Character: 6},
-					End:   protocol.Position{Line: 13, Character: 16},
+					Start: protocol.Position{Line: 19, Character: 2},
+					End:   protocol.Position{Line: 19, Character: 3},
 				},
-			}},
-		},
-		{
-			name:     "goto with overrides: string carried from import",
-			filename: "testdata/goto-overrides.jsonnet",
-			position: protocol.Position{Line: 38, Character: 57},
-			results: []definitionResult{{
-				targetFilename: "testdata/goto-overrides-imported.jsonnet",
+			},
+			{
+				targetFilename: "testdata/goto-overrides-base.jsonnet",
 				targetRange: protocol.Range{
-					Start: protocol.Position{Line: 2, Character: 4},
-					End:   protocol.Position{Line: 2, Character: 23},
+					Start: protocol.Position{Line: 16, Character: 2},
+					End:   protocol.Position{Line: 16, Character: 24},
 				},
 				targetSelectionRange: protocol.Range{
-					Start: protocol.Position{Line: 2, Character: 4},
-					End:   protocol.Position{Line: 2, Character: 15},
+					Start: protocol.Position{Line: 16, Character: 2},
+					End:   protocol.Position{Line: 16, Character: 3},
 				},
-			}},
+			},
+			{
+				targetFilename: "testdata/goto-overrides-base.jsonnet",
+				targetRange: protocol.Range{
+					Start: protocol.Position{Line: 1, Character: 2},
+					End:   protocol.Position{Line: 7, Character: 3},
+				},
+				targetSelectionRange: protocol.Range{
+					Start: protocol.Position{Line: 1, Character: 2},
+					End:   protocol.Position{Line: 1, Character: 3},
+				},
+			},
 		},
-		{
-			name:     "goto with overrides: string carried from second import",
-			filename: "testdata/goto-overrides.jsonnet",
-			position: protocol.Position{Line: 39, Character: 67},
-			results: []definitionResult{{
+	},
+	{
+		name:     "goto with overrides: nested map (multiple definitions)",
+		filename: "testdata/goto-overrides.jsonnet",
+		position: protocol.Position{Line: 33, Character: 34},
+		results: []definitionResult{
+			{
+				targetRange: protocol.Range{
+					Start: protocol.Position{Line: 25, Character: 4},
+					End:   protocol.Position{Line: 27, Character: 5},
+				},
+				targetSelectionRange: protocol.Range{
+					Start: protocol.Position{Line: 25, Character: 4},
+					End:   protocol.Position{Line: 25, Character: 11},
+				},
+			},
+			{
+				targetRange: protocol.Range{
+					Start: protocol.Position{Line: 16, Character: 4},
+					End:   protocol.Position{Line: 18, Character: 5},
+				},
+				targetSelectionRange: protocol.Range{
+					Start: protocol.Position{Line: 16, Character: 4},
+					End:   protocol.Position{Line: 16, Character: 11},
+				},
+			},
+			{
+				targetRange: protocol.Range{
+					Start: protocol.Position{Line: 4, Character: 4},
+					End:   protocol.Position{Line: 6, Character: 5},
+				},
+				targetSelectionRange: protocol.Range{
+					Start: protocol.Position{Line: 4, Character: 4},
+					End:   protocol.Position{Line: 4, Character: 11},
+				},
+			},
+			{
 				targetFilename: "testdata/goto-overrides-imported2.jsonnet",
 				targetRange: protocol.Range{
-					Start: protocol.Position{Line: 2, Character: 4},
-					End:   protocol.Position{Line: 2, Character: 30},
+					Start: protocol.Position{Line: 1, Character: 2},
+					End:   protocol.Position{Line: 3, Character: 3},
 				},
 				targetSelectionRange: protocol.Range{
-					Start: protocol.Position{Line: 2, Character: 4},
-					End:   protocol.Position{Line: 2, Character: 22},
+					Start: protocol.Position{Line: 1, Character: 2},
+					End:   protocol.Position{Line: 1, Character: 9},
 				},
-			}},
-		},
-		{
-			name:     "goto deeply nested imported attribute",
-			filename: "testdata/goto-import-nested-main.jsonnet",
-			position: protocol.Position{Line: 6, Character: 14},
-			results: []definitionResult{{
-				targetFilename: "testdata/goto-import-nested-obj.libsonnet",
+			},
+			{
+				targetFilename: "testdata/goto-overrides-imported.jsonnet",
 				targetRange: protocol.Range{
-					Start: protocol.Position{Line: 2, Character: 2},
-					End:   protocol.Position{Line: 2, Character: 26},
+					Start: protocol.Position{Line: 1, Character: 2},
+					End:   protocol.Position{Line: 3, Character: 3},
 				},
 				targetSelectionRange: protocol.Range{
-					Start: protocol.Position{Line: 2, Character: 2},
-					End:   protocol.Position{Line: 2, Character: 15},
+					Start: protocol.Position{Line: 1, Character: 2},
+					End:   protocol.Position{Line: 1, Character: 9},
 				},
-			}},
-		},
-		{
-			name:     "goto deeply nested imported attribute through self",
-			filename: "testdata/goto-import-nested-main.jsonnet",
-			position: protocol.Position{Line: 7, Character: 27},
-			results: []definitionResult{{
-				targetFilename: "testdata/goto-import-nested-obj.libsonnet",
+			},
+			{
+				targetFilename: "testdata/goto-overrides-base.jsonnet",
 				targetRange: protocol.Range{
-					Start: protocol.Position{Line: 2, Character: 2},
-					End:   protocol.Position{Line: 2, Character: 26},
+					Start: protocol.Position{Line: 12, Character: 4},
+					End:   protocol.Position{Line: 14, Character: 5},
 				},
 				targetSelectionRange: protocol.Range{
-					Start: protocol.Position{Line: 2, Character: 2},
-					End:   protocol.Position{Line: 2, Character: 15},
+					Start: protocol.Position{Line: 12, Character: 4},
+					End:   protocol.Position{Line: 12, Character: 11},
 				},
-			}},
+			},
+			{
+				targetFilename: "testdata/goto-overrides-base.jsonnet",
+				targetRange: protocol.Range{
+					Start: protocol.Position{Line: 3, Character: 4},
+					End:   protocol.Position{Line: 5, Character: 5},
+				},
+				targetSelectionRange: protocol.Range{
+					Start: protocol.Position{Line: 3, Character: 4},
+					End:   protocol.Position{Line: 3, Character: 11},
+				},
+			},
 		},
-	}
-	for _, tc := range testCases {
+	},
+	{
+		name:     "goto with overrides: string carried from super",
+		filename: "testdata/goto-overrides.jsonnet",
+		position: protocol.Position{Line: 35, Character: 27},
+		results: []definitionResult{{
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 3, Character: 4},
+				End:   protocol.Position{Line: 3, Character: 18},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 3, Character: 4},
+				End:   protocol.Position{Line: 3, Character: 9},
+			},
+		}},
+	},
+	{
+		name:     "goto with overrides: nested string carried from super",
+		filename: "testdata/goto-overrides.jsonnet",
+		position: protocol.Position{Line: 36, Character: 44},
+		results: []definitionResult{{
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 17, Character: 6},
+				End:   protocol.Position{Line: 17, Character: 22},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 17, Character: 6},
+				End:   protocol.Position{Line: 17, Character: 12},
+			},
+		}},
+	},
+	{
+		name:     "goto with overrides: string carried from local",
+		filename: "testdata/goto-overrides.jsonnet",
+		position: protocol.Position{Line: 37, Character: 57},
+		results: []definitionResult{{
+			targetFilename: "testdata/goto-overrides-base.jsonnet",
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 13, Character: 6},
+				End:   protocol.Position{Line: 13, Character: 24},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 13, Character: 6},
+				End:   protocol.Position{Line: 13, Character: 16},
+			},
+		}},
+	},
+	{
+		name:     "goto with overrides: string carried from import",
+		filename: "testdata/goto-overrides.jsonnet",
+		position: protocol.Position{Line: 38, Character: 57},
+		results: []definitionResult{{
+			targetFilename: "testdata/goto-overrides-imported.jsonnet",
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 2, Character: 4},
+				End:   protocol.Position{Line: 2, Character: 23},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 2, Character: 4},
+				End:   protocol.Position{Line: 2, Character: 15},
+			},
+		}},
+	},
+	{
+		name:     "goto with overrides: string carried from second import",
+		filename: "testdata/goto-overrides.jsonnet",
+		position: protocol.Position{Line: 39, Character: 67},
+		results: []definitionResult{{
+			targetFilename: "testdata/goto-overrides-imported2.jsonnet",
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 2, Character: 4},
+				End:   protocol.Position{Line: 2, Character: 30},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 2, Character: 4},
+				End:   protocol.Position{Line: 2, Character: 22},
+			},
+		}},
+	},
+	{
+		name:     "goto deeply nested imported attribute",
+		filename: "testdata/goto-import-nested-main.jsonnet",
+		position: protocol.Position{Line: 6, Character: 14},
+		results: []definitionResult{{
+			targetFilename: "testdata/goto-import-nested-obj.libsonnet",
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 2, Character: 2},
+				End:   protocol.Position{Line: 2, Character: 26},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 2, Character: 2},
+				End:   protocol.Position{Line: 2, Character: 15},
+			},
+		}},
+	},
+	{
+		name:     "goto deeply nested imported attribute through self",
+		filename: "testdata/goto-import-nested-main.jsonnet",
+		position: protocol.Position{Line: 7, Character: 27},
+		results: []definitionResult{{
+			targetFilename: "testdata/goto-import-nested-obj.libsonnet",
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 2, Character: 2},
+				End:   protocol.Position{Line: 2, Character: 26},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 2, Character: 2},
+				End:   protocol.Position{Line: 2, Character: 15},
+			},
+		}},
+	},
+}
+
+func TestDefinition(t *testing.T) {
+	for _, tc := range definitionTestCases {
 		t.Run(tc.name, func(t *testing.T) {
 			params := &protocol.DefinitionParams{
 				TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -757,6 +760,29 @@ func TestDefinition(t *testing.T) {
 			}
 
 			assert.Equal(t, expected, response)
+		})
+	}
+}
+
+func BenchmarkDefinition(b *testing.B) {
+	for _, tc := range definitionTestCases {
+		b.Run(tc.name, func(b *testing.B) {
+			params := &protocol.DefinitionParams{
+				TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+					TextDocument: protocol.TextDocumentIdentifier{
+						URI: protocol.URIFromPath(tc.filename),
+					},
+					Position: tc.position,
+				},
+			}
+			server := NewServer("any", "test version", nil)
+			server.getVM = testGetVM
+			serverOpenTestFile(b, server, string(tc.filename))
+
+			for i := 0; i < b.N; i++ {
+				// We don't care about the response for the benchmark
+				server.definitionLink(context.Background(), params, false)
+			}
 		})
 	}
 }

--- a/pkg/server/definition_test.go
+++ b/pkg/server/definition_test.go
@@ -781,6 +781,7 @@ func BenchmarkDefinition(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				// We don't care about the response for the benchmark
+				// nolint:errcheck
 				server.definitionLink(context.Background(), params, false)
 			}
 		})

--- a/pkg/utils/stdio.go
+++ b/pkg/utils/stdio.go
@@ -1,25 +1,40 @@
 package utils
 
 import (
+	"io"
 	"net"
 	"os"
 	"time"
 )
 
-type Stdio struct{}
+type Stdio struct {
+	in  io.ReadCloser
+	out io.WriteCloser
+}
+
+func NewDefaultStdio() *Stdio {
+	return NewStdio(os.Stdin, os.Stdout)
+}
+
+func NewStdio(in io.ReadCloser, out io.WriteCloser) *Stdio {
+	return &Stdio{
+		in:  in,
+		out: out,
+	}
+}
 
 // Read implements io.Reader interface.
-func (Stdio) Read(b []byte) (int, error) { return os.Stdin.Read(b) }
+func (s *Stdio) Read(b []byte) (int, error) { return s.in.Read(b) }
 
 // Write implements io.Writer interface.
-func (Stdio) Write(b []byte) (int, error) { return os.Stdout.Write(b) }
+func (s *Stdio) Write(b []byte) (int, error) { return s.out.Write(b) }
 
 // Close implements io.Closer interface.
-func (Stdio) Close() error {
-	if err := os.Stdin.Close(); err != nil {
+func (s *Stdio) Close() error {
+	if err := s.in.Close(); err != nil {
 		return err
 	}
-	return os.Stdout.Close()
+	return s.out.Close()
 }
 
 // LocalAddr implements net.Conn interface.


### PR DESCRIPTION
I want to refactor this code a bit but it'll be nice to see if the new code is faster
This extracts the test cases and uses them for both testing and benchmarking

To benchmark the code:
1. Run benchmark with the old code: `go test ./... -bench "BenchmarkDefinition/test_goto_definition_for_var_myvar" -count=10 > old.txt`
2. Modify the code
3. Run benchmark again: `go test ./... -bench "BenchmarkDefinition/test_goto_definition_for_var_myvar" -count=10 > new.txt`
4. Compare files: `benchstat old.txt new.txt`