### PR TITLE
Remove "no errors" diagnostics

### DIFF
--- a/pkg/server/diagnostics.go
+++ b/pkg/server/diagnostics.go
@@ -76,16 +76,6 @@ func (s *server) diagnosticsLoop() {
 						diags = append(diags, <-lintChannel...)
 					}
 
-					if len(diags) == 0 {
-						diags = []protocol.Diagnostic{
-							{
-								Source:   "jsonnet",
-								Message:  "No errors or warnings",
-								Severity: protocol.SeverityInformation,
-							},
-						}
-					}
-
 					err = s.client.PublishDiagnostics(context.Background(), &protocol.PublishDiagnosticsParams{
 						URI:         uri,
 						Diagnostics: diags,


### PR DESCRIPTION
Closes https://github.com/grafana/jsonnet-language-server/issues/44

Don't know why I needed this. I just tested again without it and VSCode is clearing the errors successfully :shrug: