### PR TITLE
Completion: Add in parameters when the suggestion is a function

### DIFF
--- a/pkg/server/completion.go
+++ b/pkg/server/completion.go
@@ -37,6 +37,7 @@ func (s *server) Completion(ctx context.Context, params *protocol.CompletionPara
 				Label:         f.Name,
 				Kind:          protocol.FunctionCompletion,
 				Detail:        f.Signature(),
+				InsertText:    strings.ReplaceAll(f.Signature(), "std.", ""),
 				Documentation: f.MarkdownDescription,
 			}
 

--- a/pkg/server/completion_test.go
+++ b/pkg/server/completion_test.go
@@ -35,18 +35,21 @@ var (
 		Label:         "aaaotherMin",
 		Kind:          protocol.FunctionCompletion,
 		Detail:        "std.aaaotherMin(a)",
+		InsertText:    "aaaotherMin(a)",
 		Documentation: "blabla",
 	}
 	minItem = protocol.CompletionItem{
 		Label:         "min",
 		Kind:          protocol.FunctionCompletion,
 		Detail:        "std.min(a, b)",
+		InsertText:    "min(a, b)",
 		Documentation: "min gets the min",
 	}
 	maxItem = protocol.CompletionItem{
 		Label:         "max",
 		Kind:          protocol.FunctionCompletion,
 		Detail:        "std.max(a, b)",
+		InsertText:    "max(a, b)",
 		Documentation: "max gets the max",
 	}
 )

--- a/pkg/stdlib/stdlib-content.jsonnet
+++ b/pkg/stdlib/stdlib-content.jsonnet
@@ -587,7 +587,7 @@ local html = import 'html.libsonnet';
         },
         {
           name: 'parseYaml',
-          availableSince: 'x.y.z',
+          availableSince: '0.18.0',
           params: ['str'],
           description: |||
             Parses a YAML string. This is provided as a "best-effort" mechanism and should not be relied on to provide


### PR DESCRIPTION
Closes https://github.com/grafana/jsonnet-language-server/issues/13
This works pretty well out of the box because the args given by the jsonnet docs are valid jsonnet
Ex:
Autocompleting `std.manifestYamlDoc` will give `std.manifestYamlDoc(value, indent_array_in_object=false, quote_keys=true)`