### PR TITLE
feat: dynamic formatting configuration

### DIFF
--- a/editor/vim/README.md
+++ b/editor/vim/README.md
@@ -8,6 +8,32 @@ The LSP integration will depend on the vim plugin you're using
 * `neoclide/coc.nvim`:
   * Inside vim, run: `:CocConfig` (to edit `~/.vim/coc-settings.json`)
   * Copy [coc-settings.json](coc-settings.json) content
+* `neovim/nvim-lspconfig`:
+  * Install jsonnet-language-server, either manually via `go install github.com/grafana/jsonnet-language-server@latest` or via
+ [williamboman/mason.nvim](https://github.com/williamboman/mason.nvim)
+   * Configure settings via [neovim/nvim-lspconfig](https://github.com/neovim/nvim-lspconfig)
+```lua
+require'lspconfig'.jsonnet_ls.setup{
+	ext_vars = {
+		foo = 'bar',
+	},
+	formatting = {
+		-- default values
+		Indent              = 2,
+		MaxBlankLines       = 2,
+		StringStyle         = 'single',
+		CommentStyle        = 'slash',
+		PrettyFieldNames    = true,
+		PadArrays           = false,
+		PadObjects          = true,
+		SortImports         = true,
+		UseImplicitPlus     = true,
+		StripEverything     = false,
+		StripComments       = false,
+		StripAllButComments = false,
+	},
+}
+```
 
 Some adjustments you may need to review for above example configs:
 * Both are preset to run `jsonnet-language-server -t`, i.e. with

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/grafana/tanka v0.19.0
 	github.com/hexops/gotextdiff v1.0.3
 	github.com/jdbaldry/go-language-server-protocol v0.0.0-20211013214444-3022da0884b2
+	github.com/mitchellh/mapstructure v1.5.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
 )
@@ -27,7 +28,6 @@ require (
 	github.com/mattn/go-colorable v0.1.9 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mitchellh/copystructure v1.0.0 // indirect
-	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/mattn/go-colorable v0.1.9 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mitchellh/copystructure v1.0.0 // indirect
+	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
+github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
+github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.0 h1:9D+8oIskB4VJBN5SFlmc27fSlIBZaov1Wpk/IfikLNY=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pkg/server/configuration.go
+++ b/pkg/server/configuration.go
@@ -90,24 +90,6 @@ func resetExtVars(vm *jsonnet.VM, vars map[string]string) {
 	}
 }
 
-func assignCommentStyle(dest *formatter.CommentStyle, unparsed interface{}) error {
-	str, ok := unparsed.(string)
-	if !ok {
-		return fmt.Errorf("expected string, got: %T", unparsed)
-	}
-	switch str {
-	case "hash":
-		*dest = formatter.CommentStyleHash
-	case "slash":
-		*dest = formatter.CommentStyleSlash
-	case "leave":
-		*dest = formatter.CommentStyleLeave
-	default:
-		return fmt.Errorf("expected one of 'hash', 'slash', 'leave', got: %q", str)
-	}
-	return nil
-}
-
 func stringStyleDecodeFunc(from, to reflect.Type, unparsed interface{}) (interface{}, error) {
 	if to != reflect.TypeOf(formatter.StringStyleDouble) {
 		return unparsed, nil

--- a/pkg/server/configuration.go
+++ b/pkg/server/configuration.go
@@ -65,29 +65,37 @@ func (s *server) parseFormattingOpts(unparsed interface{}) (formatter.Options, e
 	}
 
 	opts := formatter.DefaultOptions()
-	optsTyp, optsVal := reflect.TypeOf(opts), reflect.ValueOf(&opts).Elem()
+	var (
+		valOpts = reflect.ValueOf(&opts).Elem()
+		typOpts = valOpts.Type()
+
+		typBool         = reflect.TypeOf(false)
+		typInt          = reflect.TypeOf(int(0))
+		typStringStyle  = reflect.TypeOf(formatter.StringStyleDouble)
+		typCommentStyle = reflect.TypeOf(formatter.CommentStyleHash)
+	)
 	for optName, unparsedValue := range newOpts {
-		field, ok := optsTyp.FieldByName(optName)
+		field, ok := typOpts.FieldByName(optName)
 		if !ok {
 			return opts, fmt.Errorf("unknown option: %q", optName)
 		}
 
 		var err error
 		switch field.Type {
-		case reflect.TypeOf(int(0)):
-			dest := optsVal.FieldByIndex(field.Index).Addr().Interface().(*int)
+		case typInt:
+			dest := valOpts.FieldByIndex(field.Index).Addr().Interface().(*int)
 			err = assignInt(dest, unparsedValue)
 
-		case reflect.TypeOf(false):
-			dest := optsVal.FieldByIndex(field.Index).Addr().Interface().(*bool)
+		case typBool:
+			dest := valOpts.FieldByIndex(field.Index).Addr().Interface().(*bool)
 			err = assignBool(dest, unparsedValue)
 
-		case reflect.TypeOf(formatter.StringStyleDouble):
-			dest := optsVal.FieldByIndex(field.Index).Addr().Interface().(*formatter.StringStyle)
+		case typStringStyle:
+			dest := valOpts.FieldByIndex(field.Index).Addr().Interface().(*formatter.StringStyle)
 			err = assignStringStyle(dest, unparsedValue)
 
-		case reflect.TypeOf(formatter.CommentStyleHash):
-			dest := optsVal.FieldByIndex(field.Index).Addr().Interface().(*formatter.CommentStyle)
+		case typCommentStyle:
+			dest := valOpts.FieldByIndex(field.Index).Addr().Interface().(*formatter.CommentStyle)
 			err = assignCommentStyle(dest, unparsedValue)
 
 		default:
@@ -96,36 +104,6 @@ func (s *server) parseFormattingOpts(unparsed interface{}) (formatter.Options, e
 		if err != nil {
 			return opts, fmt.Errorf("%s: %v", optName, err)
 		}
-
-		// switch optName {
-		// case "indent":
-		// 	if err := assignInt(&opts.Indent, unparsedValue); err != nil {
-		// 		return opts, fmt.Errorf("indent: %v", err)
-		// 	}
-		// case "max_blank_lines":
-		// 	if err := assignInt(&opts.MaxBlankLines, unparsedValue); err != nil {
-		// 		return opts, fmt.Errorf("max_blank_lines: %v", err)
-		// 	}
-		// case "string_style":
-		// 	if err := assignStringStyle(&opts.StringStyle, unparsedValue); err != nil {
-		// 		return opts, fmt.Errorf("string_style: %v", err)
-		// 	}
-		// case "comment_style":
-		// 	if err := assignCommentStyle(&opts.CommentStyle, unparsedValue); err != nil {
-		// 		return opts, fmt.Errorf("comment_style: %v", err)
-		// 	}
-		// case "pretty_field_names":
-		// 	if err := assignBool(&opts.PrettyFieldNames, unparsedValue); err != nil {
-		// 		return opts, fmt.Errorf("pretty_field_names: %v", err)
-		// 	}
-		// case "pad_arrays":
-		// 	if err := assignBool(&opts.PadArrays, unparsedValue); err != nil {
-		// 		return opts, fmt.Errorf("pad_arrays: %v", err)
-		// 	}
-
-		// default:
-		// 	return opts, fmt.Errorf("unknown option: %q", optName)
-		// }
 	}
 	return opts, nil
 }

--- a/pkg/server/configuration.go
+++ b/pkg/server/configuration.go
@@ -3,8 +3,11 @@ package server
 import (
 	"context"
 	"fmt"
+	"math"
+	"reflect"
 
 	"github.com/google/go-jsonnet"
+	"github.com/google/go-jsonnet/formatter"
 	"github.com/jdbaldry/go-language-server-protocol/jsonrpc2"
 	"github.com/jdbaldry/go-language-server-protocol/lsp/protocol"
 )
@@ -23,6 +26,13 @@ func (s *server) DidChangeConfiguration(ctx context.Context, params *protocol.Di
 				return fmt.Errorf("%w: ext_vars parsing failed: %v", jsonrpc2.ErrInvalidParams, err)
 			}
 			s.extVars = newVars
+
+		case "formatting":
+			newFmtOpts, err := s.parseFormattingOpts(sv)
+			if err != nil {
+				return fmt.Errorf("%w: formatting options parsing failed: %v", jsonrpc2.ErrInvalidParams, err)
+			}
+			s.fmtOpts = newFmtOpts
 
 		default:
 			return fmt.Errorf("%w: unsupported settings key: %q", jsonrpc2.ErrInvalidParams, sk)
@@ -48,9 +58,141 @@ func (s *server) parseExtVars(unparsed interface{}) (map[string]string, error) {
 	return extVars, nil
 }
 
+func (s *server) parseFormattingOpts(unparsed interface{}) (formatter.Options, error) {
+	newOpts, ok := unparsed.(map[string]interface{})
+	if !ok {
+		return formatter.Options{}, fmt.Errorf("unsupported settings value for formatting. expected json object. got: %T", unparsed)
+	}
+
+	opts := formatter.DefaultOptions()
+	optsTyp, optsVal := reflect.TypeOf(opts), reflect.ValueOf(&opts).Elem()
+	for optName, unparsedValue := range newOpts {
+		field, ok := optsTyp.FieldByName(optName)
+		if !ok {
+			return opts, fmt.Errorf("unknown option: %q", optName)
+		}
+
+		var err error
+		switch field.Type {
+		case reflect.TypeOf(int(0)):
+			dest := optsVal.FieldByIndex(field.Index).Addr().Interface().(*int)
+			err = assignInt(dest, unparsedValue)
+
+		case reflect.TypeOf(false):
+			dest := optsVal.FieldByIndex(field.Index).Addr().Interface().(*bool)
+			err = assignBool(dest, unparsedValue)
+
+		case reflect.TypeOf(formatter.StringStyleDouble):
+			dest := optsVal.FieldByIndex(field.Index).Addr().Interface().(*formatter.StringStyle)
+			err = assignStringStyle(dest, unparsedValue)
+
+		case reflect.TypeOf(formatter.CommentStyleHash):
+			dest := optsVal.FieldByIndex(field.Index).Addr().Interface().(*formatter.CommentStyle)
+			err = assignCommentStyle(dest, unparsedValue)
+
+		default:
+			err = fmt.Errorf("unknown field type: %v", field.Type)
+		}
+		if err != nil {
+			return opts, fmt.Errorf("%s: %v", optName, err)
+		}
+
+		// switch optName {
+		// case "indent":
+		// 	if err := assignInt(&opts.Indent, unparsedValue); err != nil {
+		// 		return opts, fmt.Errorf("indent: %v", err)
+		// 	}
+		// case "max_blank_lines":
+		// 	if err := assignInt(&opts.MaxBlankLines, unparsedValue); err != nil {
+		// 		return opts, fmt.Errorf("max_blank_lines: %v", err)
+		// 	}
+		// case "string_style":
+		// 	if err := assignStringStyle(&opts.StringStyle, unparsedValue); err != nil {
+		// 		return opts, fmt.Errorf("string_style: %v", err)
+		// 	}
+		// case "comment_style":
+		// 	if err := assignCommentStyle(&opts.CommentStyle, unparsedValue); err != nil {
+		// 		return opts, fmt.Errorf("comment_style: %v", err)
+		// 	}
+		// case "pretty_field_names":
+		// 	if err := assignBool(&opts.PrettyFieldNames, unparsedValue); err != nil {
+		// 		return opts, fmt.Errorf("pretty_field_names: %v", err)
+		// 	}
+		// case "pad_arrays":
+		// 	if err := assignBool(&opts.PadArrays, unparsedValue); err != nil {
+		// 		return opts, fmt.Errorf("pad_arrays: %v", err)
+		// 	}
+
+		// default:
+		// 	return opts, fmt.Errorf("unknown option: %q", optName)
+		// }
+	}
+	return opts, nil
+}
+
 func resetExtVars(vm *jsonnet.VM, vars map[string]string) {
 	vm.ExtReset()
 	for vk, vv := range vars {
 		vm.ExtVar(vk, vv)
 	}
+}
+
+func assignBool(dest *bool, unparsed interface{}) error {
+	switch unparsed {
+	case true:
+		*dest = true
+	case false:
+		*dest = false
+	default:
+		return fmt.Errorf("expected bool, got: %T", unparsed)
+	}
+	return nil
+}
+
+func assignInt(dest *int, unparsed interface{}) error {
+	switch v := unparsed.(type) {
+	case int:
+		*dest = v
+	case float64:
+		*dest = int(math.Floor(v))
+	default:
+		return fmt.Errorf("expected int or float, got: %T", unparsed)
+	}
+	return nil
+}
+
+func assignCommentStyle(dest *formatter.CommentStyle, unparsed interface{}) error {
+	str, ok := unparsed.(string)
+	if !ok {
+		return fmt.Errorf("expected string, got: %T", unparsed)
+	}
+	switch str {
+	case "hash":
+		*dest = formatter.CommentStyleHash
+	case "slash":
+		*dest = formatter.CommentStyleSlash
+	case "leave":
+		*dest = formatter.CommentStyleLeave
+	default:
+		return fmt.Errorf("expected one of 'hash', 'slash', 'leave', got: %q", str)
+	}
+	return nil
+}
+
+func assignStringStyle(dest *formatter.StringStyle, unparsed interface{}) error {
+	str, ok := unparsed.(string)
+	if !ok {
+		return fmt.Errorf("expected string, got: %T", unparsed)
+	}
+	switch str {
+	case "double":
+		*dest = formatter.StringStyleDouble
+	case "single":
+		*dest = formatter.StringStyleSingle
+	case "leave":
+		*dest = formatter.StringStyleLeave
+	default:
+		return fmt.Errorf("unknown string_style: expected one of 'double', 'single', 'leave', got: %q", str)
+	}
+	return nil
 }

--- a/pkg/server/configuration_test.go
+++ b/pkg/server/configuration_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/google/go-jsonnet/formatter"
 	"github.com/jdbaldry/go-language-server-protocol/lsp/protocol"
 	"github.com/stretchr/testify/assert"
 )
@@ -114,6 +115,75 @@ func TestConfiguration(t *testing.T) {
 			json, err := vm.Evaluate(doc.ast)
 			assert.NoError(t, err)
 			assert.JSONEq(t, tc.expectedFileOutput, json)
+		})
+	}
+}
+
+func TestConfiguration_Formatting(t *testing.T) {
+	type kase struct {
+		name            string
+		settings        interface{}
+		expectedOptions formatter.Options
+		expectedErr     error
+	}
+
+	testCases := []kase{
+		{
+			name: "formatting opts",
+			settings: map[string]interface{}{
+				"formatting": map[string]interface{}{
+					"Indent":           4,
+					"MaxBlankLines":    10,
+					"StringStyle":      "single",
+					"CommentStyle":     "leave",
+					"PrettyFieldNames": true,
+					"PadArrays":        false,
+					"PadObjects":       true,
+					"SortImports":      false,
+					"UseImplicitPlus":  true,
+					"StripEverything":  false,
+					"StripComments":    false,
+					// not setting StripAllButComments
+				},
+			},
+			expectedOptions: func() formatter.Options {
+				opts := formatter.DefaultOptions()
+				opts.Indent = 4
+				opts.MaxBlankLines = 10
+				opts.StringStyle = formatter.StringStyleSingle
+				opts.CommentStyle = formatter.CommentStyleLeave
+				opts.PrettyFieldNames = true
+				opts.PadArrays = false
+				opts.PadObjects = true
+				opts.SortImports = false
+				opts.UseImplicitPlus = true
+				opts.StripEverything = false
+				opts.StripComments = false
+				return opts
+			}(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			s, _ := testServerWithFile(t, nil, "")
+
+			err := s.DidChangeConfiguration(
+				context.TODO(),
+				&protocol.DidChangeConfigurationParams{
+					Settings: tc.settings,
+				},
+			)
+			if tc.expectedErr == nil && err != nil {
+				t.Fatalf("DidChangeConfiguration produced unexpected error: %v", err)
+			} else if tc.expectedErr != nil && err == nil {
+				t.Fatalf("expected DidChangeConfiguration to produce error but it did not")
+			} else if tc.expectedErr != nil && err != nil {
+				assert.EqualError(t, err, tc.expectedErr.Error())
+				return
+			}
+
+			assert.Equal(t, tc.expectedOptions, s.fmtOpts)
 		})
 	}
 }

--- a/pkg/server/configuration_test.go
+++ b/pkg/server/configuration_test.go
@@ -162,6 +162,31 @@ func TestConfiguration_Formatting(t *testing.T) {
 				return opts
 			}(),
 		},
+		{
+			name: "invalid string style",
+			settings: map[string]interface{}{
+				"formatting": map[string]interface{}{
+					"StringStyle": "invalid",
+				},
+			},
+			expectedErr: errors.New("JSON RPC invalid params: formatting options parsing failed: map decode failed: 1 error(s) decoding:\n\n* error decoding 'StringStyle': expected one of 'double', 'single', 'leave', got: \"invalid\""),
+		},
+		{
+			name: "invalid comment style",
+			settings: map[string]interface{}{
+				"formatting": map[string]interface{}{
+					"CommentStyle": "invalid",
+				},
+			},
+			expectedErr: errors.New("JSON RPC invalid params: formatting options parsing failed: map decode failed: 1 error(s) decoding:\n\n* error decoding 'CommentStyle': expected one of 'hash', 'slash', 'leave', got: \"invalid\""),
+		},
+		{
+			name: "does not override default values",
+			settings: map[string]interface{}{
+				"formatting": map[string]interface{}{},
+			},
+			expectedOptions: formatter.DefaultOptions(),
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/server/formatting.go
+++ b/pkg/server/formatting.go
@@ -17,8 +17,7 @@ func (s *server) Formatting(ctx context.Context, params *protocol.DocumentFormat
 		return nil, utils.LogErrorf("Formatting: %s: %w", errorRetrievingDocument, err)
 	}
 
-	// TODO(#14): Formatting options should be user configurable.
-	formatted, err := formatter.Format(params.TextDocument.URI.SpanURI().Filename(), doc.item.Text, formatter.DefaultOptions())
+	formatted, err := formatter.Format(params.TextDocument.URI.SpanURI().Filename(), doc.item.Text, s.fmtOpts)
 	if err != nil {
 		log.Errorf("error formatting document: %v", err)
 		return nil, nil

--- a/pkg/server/formatting_test.go
+++ b/pkg/server/formatting_test.go
@@ -1,10 +1,13 @@
 package server
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	"github.com/jdbaldry/go-language-server-protocol/lsp/protocol"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetTextEdits(t *testing.T) {
@@ -70,4 +73,86 @@ func TestGetTextEdits(t *testing.T) {
 			assert.Equal(t, tc.expected, got)
 		})
 	}
+}
+
+func TestFormatting(t *testing.T) {
+	type kase struct {
+		name        string
+		settings    interface{}
+		fileContent string
+
+		expected []protocol.TextEdit
+	}
+	testCases := []kase{
+		{
+			name:     "default settings",
+			settings: nil,
+			fileContent: "{foo:		'bar'}",
+			expected: []protocol.TextEdit{
+				{Range: makeRange(t, "0:0-1:0"), NewText: ""},
+				{Range: makeRange(t, "1:0-1:0"), NewText: "{ foo: 'bar' }\n"},
+			},
+		},
+		{
+			name: "new lines with indentation",
+			settings: map[string]interface{}{
+				"formatting": map[string]interface{}{"Indent": 4},
+			},
+			fileContent: `
+{
+	foo: 'bar',
+}`,
+			expected: []protocol.TextEdit{
+				{Range: makeRange(t, "0:0-1:0"), NewText: ""},
+				{Range: makeRange(t, "2:0-3:0"), NewText: ""},
+				{Range: makeRange(t, "3:0-4:0"), NewText: ""},
+				{Range: makeRange(t, "4:0-4:0"), NewText: "    foo: 'bar',\n"},
+				{Range: makeRange(t, "4:0-4:0"), NewText: "}\n"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			s, fileURI := testServerWithFile(t, nil, tc.fileContent)
+
+			if tc.settings != nil {
+				err := s.DidChangeConfiguration(
+					context.TODO(),
+					&protocol.DidChangeConfigurationParams{
+						Settings: tc.settings,
+					},
+				)
+				require.NoError(t, err, "expected settings to not return an error")
+			}
+
+			edits, err := s.Formatting(context.TODO(), &protocol.DocumentFormattingParams{
+				TextDocument: protocol.TextDocumentIdentifier{
+					URI: fileURI,
+				},
+			})
+			require.NoError(t, err, "expected Formatting to not return an error")
+			assert.Equal(t, tc.expected, edits)
+		})
+	}
+}
+
+// makeRange parses rangeStr of the form
+// <start-line>:<start-col>-<end-line>:<end-col> into a valid protocol.Range
+func makeRange(t *testing.T, rangeStr string) protocol.Range {
+	ret := protocol.Range{
+		Start: protocol.Position{Line: 0, Character: 0},
+		End:   protocol.Position{Line: 0, Character: 0},
+	}
+	n, err := fmt.Sscanf(
+		rangeStr,
+		"%d:%d-%d:%d",
+		&ret.Start.Line,
+		&ret.Start.Character,
+		&ret.End.Line,
+		&ret.End.Character,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 4, n)
+	return ret
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 
 	"github.com/google/go-jsonnet"
+	"github.com/google/go-jsonnet/formatter"
 	"github.com/grafana/jsonnet-language-server/pkg/stdlib"
 	"github.com/grafana/jsonnet-language-server/pkg/utils"
 	tankaJsonnet "github.com/grafana/tanka/pkg/jsonnet"
@@ -40,6 +41,7 @@ func NewServer(name, version string, client protocol.ClientCloser) *server {
 		version: version,
 		cache:   newCache(),
 		client:  client,
+		fmtOpts: formatter.DefaultOptions(),
 	}
 
 	return server
@@ -54,6 +56,7 @@ type server struct {
 	client  protocol.ClientCloser
 	getVM   func(path string) (*jsonnet.VM, error)
 	extVars map[string]string
+	fmtOpts formatter.Options
 
 	// Feature flags
 	EvalDiags bool


### PR DESCRIPTION
Allow users to customize the formatting parameters using LSP runtime configuration, which is modifiable w/o restarting the jsonnet-language-server.

Sample configuration looks like:

```
settings = {
	formatting = {
		Indent = 4,
		StringStyle = 'double',
	},
}
```

See `TestConfiguration_Formatting` for a complete list of allowed keys.