### PR TITLE
Add support for configuring everything with `DidChangeConfiguration`

### DIFF
--- a/pkg/server/configuration_test.go
+++ b/pkg/server/configuration_test.go
@@ -121,10 +121,10 @@ func TestConfiguration(t *testing.T) {
 
 func TestConfiguration_Formatting(t *testing.T) {
 	type kase struct {
-		name            string
-		settings        interface{}
-		expectedOptions formatter.Options
-		expectedErr     error
+		name                  string
+		settings              interface{}
+		expectedConfiguration Configuration
+		expectedErr           error
 	}
 
 	testCases := []kase{
@@ -146,21 +146,23 @@ func TestConfiguration_Formatting(t *testing.T) {
 					// not setting StripAllButComments
 				},
 			},
-			expectedOptions: func() formatter.Options {
-				opts := formatter.DefaultOptions()
-				opts.Indent = 4
-				opts.MaxBlankLines = 10
-				opts.StringStyle = formatter.StringStyleSingle
-				opts.CommentStyle = formatter.CommentStyleLeave
-				opts.PrettyFieldNames = true
-				opts.PadArrays = false
-				opts.PadObjects = true
-				opts.SortImports = false
-				opts.UseImplicitPlus = true
-				opts.StripEverything = false
-				opts.StripComments = false
-				return opts
-			}(),
+			expectedConfiguration: Configuration{
+				FormattingOptions: func() formatter.Options {
+					opts := formatter.DefaultOptions()
+					opts.Indent = 4
+					opts.MaxBlankLines = 10
+					opts.StringStyle = formatter.StringStyleSingle
+					opts.CommentStyle = formatter.CommentStyleLeave
+					opts.PrettyFieldNames = true
+					opts.PadArrays = false
+					opts.PadObjects = true
+					opts.SortImports = false
+					opts.UseImplicitPlus = true
+					opts.StripEverything = false
+					opts.StripComments = false
+					return opts
+				}(),
+			},
 		},
 		{
 			name: "invalid string style",
@@ -185,7 +187,58 @@ func TestConfiguration_Formatting(t *testing.T) {
 			settings: map[string]interface{}{
 				"formatting": map[string]interface{}{},
 			},
-			expectedOptions: formatter.DefaultOptions(),
+			expectedConfiguration: Configuration{FormattingOptions: formatter.DefaultOptions()},
+		},
+		{
+			name: "all settings",
+			settings: map[string]interface{}{
+				"formatting": map[string]interface{}{
+					"Indent":              4,
+					"MaxBlankLines":       10,
+					"StringStyle":         "double",
+					"CommentStyle":        "slash",
+					"PrettyFieldNames":    false,
+					"PadArrays":           true,
+					"PadObjects":          false,
+					"SortImports":         false,
+					"UseImplicitPlus":     false,
+					"StripEverything":     true,
+					"StripComments":       true,
+					"StripAllButComments": true,
+				},
+				"ext_vars": map[string]interface{}{
+					"hello": "world",
+				},
+				"resolve_paths_with_tanka": false,
+				"jpath":                    []interface{}{"blabla", "blabla2"},
+				"enable_eval_diagnostics":  false,
+				"enable_lint_diagnostics":  true,
+			},
+			expectedConfiguration: Configuration{
+				FormattingOptions: func() formatter.Options {
+					opts := formatter.DefaultOptions()
+					opts.Indent = 4
+					opts.MaxBlankLines = 10
+					opts.StringStyle = formatter.StringStyleDouble
+					opts.CommentStyle = formatter.CommentStyleSlash
+					opts.PrettyFieldNames = false
+					opts.PadArrays = true
+					opts.PadObjects = false
+					opts.SortImports = false
+					opts.UseImplicitPlus = false
+					opts.StripEverything = true
+					opts.StripComments = true
+					opts.StripAllButComments = true
+					return opts
+				}(),
+				ExtVars: map[string]string{
+					"hello": "world",
+				},
+				ResolvePathsWithTanka: false,
+				JPaths:                []string{"blabla", "blabla2"},
+				EnableEvalDiagnostics: false,
+				EnableLintDiagnostics: true,
+			},
 		},
 	}
 
@@ -208,7 +261,7 @@ func TestConfiguration_Formatting(t *testing.T) {
 				return
 			}
 
-			assert.Equal(t, tc.expectedOptions, s.fmtOpts)
+			assert.Equal(t, tc.expectedConfiguration, s.configuration)
 		})
 	}
 }

--- a/pkg/server/definition_test.go
+++ b/pkg/server/definition_test.go
@@ -737,8 +737,9 @@ func TestDefinition(t *testing.T) {
 				},
 			}
 
-			server := NewServer("any", "test version", nil)
-			server.getVM = testGetVM
+			server := NewServer("any", "test version", nil, Configuration{
+				JPaths: []string{"testdata"},
+			})
 			serverOpenTestFile(t, server, string(tc.filename))
 			response, err := server.definitionLink(context.Background(), params)
 			require.NoError(t, err)
@@ -775,8 +776,9 @@ func BenchmarkDefinition(b *testing.B) {
 					Position: tc.position,
 				},
 			}
-			server := NewServer("any", "test version", nil)
-			server.getVM = testGetVM
+			server := NewServer("any", "test version", nil, Configuration{
+				JPaths: []string{"testdata"},
+			})
 			serverOpenTestFile(b, server, string(tc.filename))
 
 			for i := 0; i < b.N; i++ {
@@ -845,8 +847,9 @@ func TestDefinitionFail(t *testing.T) {
 				},
 			}
 
-			server := NewServer("any", "test version", nil)
-			server.getVM = testGetVM
+			server := NewServer("any", "test version", nil, Configuration{
+				JPaths: []string{"testdata"},
+			})
 			serverOpenTestFile(t, server, tc.filename)
 			got, err := server.definitionLink(context.Background(), params)
 

--- a/pkg/server/diagnostics.go
+++ b/pkg/server/diagnostics.go
@@ -105,7 +105,7 @@ func (s *server) diagnosticsLoop() {
 					}()
 
 					lintChannel := make(chan []protocol.Diagnostic, 1)
-					if s.LintDiags {
+					if s.configuration.EnableLintDiagnostics {
 						go func() {
 							lintChannel <- s.getLintDiags(doc)
 						}()
@@ -113,7 +113,7 @@ func (s *server) diagnosticsLoop() {
 
 					diags = append(diags, <-evalChannel...)
 
-					if s.LintDiags {
+					if s.configuration.EnableLintDiagnostics {
 						err = s.client.PublishDiagnostics(context.Background(), &protocol.PublishDiagnosticsParams{
 							URI:         uri,
 							Diagnostics: diags,
@@ -149,7 +149,7 @@ func (s *server) diagnosticsLoop() {
 }
 
 func (s *server) getEvalDiags(doc *document) (diags []protocol.Diagnostic) {
-	if doc.err == nil && s.EvalDiags {
+	if doc.err == nil && s.configuration.EnableEvalDiagnostics {
 		vm, err := s.getVM(doc.item.URI.SpanURI().Filename())
 		if err != nil {
 			log.Errorf("getEvalDiags: %s: %v\n", errorRetrievingDocument, err)

--- a/pkg/server/formatting.go
+++ b/pkg/server/formatting.go
@@ -17,7 +17,7 @@ func (s *server) Formatting(ctx context.Context, params *protocol.DocumentFormat
 		return nil, utils.LogErrorf("Formatting: %s: %w", errorRetrievingDocument, err)
 	}
 
-	formatted, err := formatter.Format(params.TextDocument.URI.SpanURI().Filename(), doc.item.Text, s.fmtOpts)
+	formatted, err := formatter.Format(params.TextDocument.URI.SpanURI().Filename(), doc.item.Text, s.configuration.FormattingOptions)
 	if err != nil {
 		log.Errorf("error formatting document: %v", err)
 		return nil, nil

--- a/pkg/server/formatting_test.go
+++ b/pkg/server/formatting_test.go
@@ -85,8 +85,8 @@ func TestFormatting(t *testing.T) {
 	}
 	testCases := []kase{
 		{
-			name:     "default settings",
-			settings: nil,
+			name:        "default settings",
+			settings:    nil,
 			fileContent: "{foo:		'bar'}",
 			expected: []protocol.TextEdit{
 				{Range: makeRange(t, "0:0-1:0"), NewText: ""},

--- a/pkg/server/utils_test.go
+++ b/pkg/server/utils_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/google/go-jsonnet"
+	"github.com/google/go-jsonnet/formatter"
 	"github.com/grafana/jsonnet-language-server/pkg/stdlib"
 	"github.com/grafana/jsonnet-language-server/pkg/utils"
 	"github.com/jdbaldry/go-language-server-protocol/jsonrpc2"
@@ -42,7 +42,9 @@ func testServer(t *testing.T, stdlib []stdlib.Function) (server *server) {
 	stream := jsonrpc2.NewHeaderStream(utils.NewStdio(nil, fakeWriterCloser{io.Discard}))
 	conn := jsonrpc2.NewConn(stream)
 	client := protocol.ClientDispatcher(conn)
-	server = NewServer("jsonnet-language-server", "dev", client).WithStaticVM([]string{})
+	server = NewServer("jsonnet-language-server", "dev", client, Configuration{
+		FormattingOptions: formatter.DefaultOptions(),
+	})
 	server.stdlib = stdlib
 	_, err := server.Initialize(context.Background(), &protocol.ParamInitialize{})
 	require.NoError(t, err)
@@ -80,10 +82,4 @@ func testServerWithFile(t *testing.T, stdlib []stdlib.Function, fileContent stri
 	require.NoError(t, err)
 
 	return server, serverOpenTestFile(t, server, tmpFile.Name())
-}
-
-func testGetVM(path string) (*jsonnet.VM, error) {
-	vm := jsonnet.MakeVM()
-	vm.Importer(&jsonnet.FileImporter{JPaths: []string{"testdata"}})
-	return vm, nil
 }


### PR DESCRIPTION
Continues @entombedvirus's work in #37 and #47
With this, we can now configure everything using the configuration endpoint
This will allow IDE extensions to change configurations without restarting the server
Command line configs are still supported, for retro-compatibility and for looser integrations (like vim and emacs use)