### PR TITLE
Symbols support

### DIFF
--- a/pkg/ast_processing/find_bind.go
+++ b/pkg/ast_processing/find_bind.go
@@ -1,4 +1,4 @@
-package processing
+package ast_processing
 
 import (
 	"github.com/google/go-jsonnet/ast"

--- a/pkg/ast_processing/find_field.go
+++ b/pkg/ast_processing/find_field.go
@@ -1,4 +1,4 @@
-package processing
+package ast_processing
 
 import (
 	"fmt"
@@ -9,30 +9,6 @@ import (
 	"github.com/grafana/jsonnet-language-server/pkg/nodestack"
 	log "github.com/sirupsen/logrus"
 )
-
-type ObjectRange struct {
-	Filename       string
-	SelectionRange ast.LocationRange
-	FullRange      ast.LocationRange
-}
-
-func FieldToRange(field *ast.DesugaredObjectField) ObjectRange {
-	selectionRange := ast.LocationRange{
-		Begin: ast.Location{
-			Line:   field.LocRange.Begin.Line,
-			Column: field.LocRange.Begin.Column,
-		},
-		End: ast.Location{
-			Line:   field.LocRange.Begin.Line,
-			Column: field.LocRange.Begin.Column + len(field.Name.(*ast.LiteralString).Value),
-		},
-	}
-	return ObjectRange{
-		Filename:       field.LocRange.FileName,
-		SelectionRange: selectionRange,
-		FullRange:      field.LocRange,
-	}
-}
 
 func FindRangesFromIndexList(stack *nodestack.NodeStack, indexList []string, vm *jsonnet.VM) ([]ObjectRange, error) {
 	var foundDesugaredObjects []*ast.DesugaredObject

--- a/pkg/ast_processing/find_param.go
+++ b/pkg/ast_processing/find_param.go
@@ -1,4 +1,4 @@
-package processing
+package ast_processing
 
 import (
 	"github.com/google/go-jsonnet/ast"

--- a/pkg/ast_processing/find_position.go
+++ b/pkg/ast_processing/find_position.go
@@ -1,4 +1,4 @@
-package processing
+package ast_processing
 
 import (
 	"errors"

--- a/pkg/ast_processing/object.go
+++ b/pkg/ast_processing/object.go
@@ -1,4 +1,4 @@
-package processing
+package ast_processing
 
 import (
 	"github.com/google/go-jsonnet/ast"

--- a/pkg/ast_processing/object_range.go
+++ b/pkg/ast_processing/object_range.go
@@ -1,0 +1,51 @@
+package ast_processing
+
+import (
+	"github.com/google/go-jsonnet/ast"
+)
+
+type ObjectRange struct {
+	Filename       string
+	SelectionRange ast.LocationRange
+	FullRange      ast.LocationRange
+}
+
+func FieldToRange(field *ast.DesugaredObjectField) ObjectRange {
+	selectionRange := ast.LocationRange{
+		Begin: ast.Location{
+			Line:   field.LocRange.Begin.Line,
+			Column: field.LocRange.Begin.Column,
+		},
+		End: ast.Location{
+			Line:   field.LocRange.Begin.Line,
+			Column: field.LocRange.Begin.Column + len(field.Name.(*ast.LiteralString).Value),
+		},
+	}
+	return ObjectRange{
+		Filename:       field.LocRange.FileName,
+		SelectionRange: selectionRange,
+		FullRange:      field.LocRange,
+	}
+}
+
+func LocalBindToRange(bind *ast.LocalBind) ObjectRange {
+	locRange := bind.LocRange
+	if !locRange.Begin.IsSet() {
+		locRange = *bind.Body.Loc()
+	}
+	filename := locRange.FileName
+	return ObjectRange{
+		Filename:  filename,
+		FullRange: locRange,
+		SelectionRange: ast.LocationRange{
+			Begin: ast.Location{
+				Line:   locRange.Begin.Line,
+				Column: locRange.Begin.Column,
+			},
+			End: ast.Location{
+				Line:   locRange.Begin.Line,
+				Column: locRange.Begin.Column + len(bind.Variable),
+			},
+		},
+	}
+}

--- a/pkg/ast_processing/range.go
+++ b/pkg/ast_processing/range.go
@@ -1,4 +1,4 @@
-package processing
+package ast_processing
 
 import "github.com/google/go-jsonnet/ast"
 

--- a/pkg/ast_processing/top_level_objects.go
+++ b/pkg/ast_processing/top_level_objects.go
@@ -1,4 +1,4 @@
-package processing
+package ast_processing
 
 import (
 	"github.com/google/go-jsonnet"

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -130,6 +130,7 @@ func (s *server) Initialize(ctx context.Context, params *protocol.ParamInitializ
 			HoverProvider:              true,
 			DefinitionProvider:         true,
 			DocumentFormattingProvider: true,
+			DocumentSymbolProvider:     true,
 			ExecuteCommandProvider:     protocol.ExecuteCommandOptions{Commands: []string{}},
 			TextDocumentSync: &protocol.TextDocumentSyncOptions{
 				Change:    protocol.Full,

--- a/pkg/server/symbols.go
+++ b/pkg/server/symbols.go
@@ -1,0 +1,113 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/google/go-jsonnet/ast"
+	processing "github.com/grafana/jsonnet-language-server/pkg/ast_processing"
+	position "github.com/grafana/jsonnet-language-server/pkg/position_conversion"
+	"github.com/grafana/jsonnet-language-server/pkg/utils"
+	"github.com/jdbaldry/go-language-server-protocol/lsp/protocol"
+)
+
+func (s *server) DocumentSymbol(ctx context.Context, params *protocol.DocumentSymbolParams) ([]interface{}, error) {
+	doc, err := s.cache.get(params.TextDocument.URI)
+	if err != nil {
+		return nil, utils.LogErrorf("Definition: %s: %w", errorRetrievingDocument, err)
+	}
+
+	if doc.ast == nil {
+		return nil, utils.LogErrorf("Definition: error parsing the document")
+	}
+
+	symbols := buildDocumentSymbols(doc.ast)
+
+	result := make([]interface{}, len(symbols))
+	for i, symbol := range symbols {
+		result[i] = symbol
+	}
+
+	return result, nil
+}
+
+func buildDocumentSymbols(node ast.Node) []protocol.DocumentSymbol {
+	var symbols []protocol.DocumentSymbol
+
+	switch node := node.(type) {
+	case *ast.Binary:
+		symbols = append(symbols, buildDocumentSymbols(node.Left)...)
+		symbols = append(symbols, buildDocumentSymbols(node.Right)...)
+	case *ast.Local:
+		for _, bind := range node.Binds {
+			locRange := bind.LocRange
+			if !locRange.IsSet() {
+				locRange = *bind.Body.Loc()
+			}
+			resultRange := position.RangeASTToProtocol(locRange)
+			resultSelectionRange := position.NewProtocolRange(
+				locRange.Begin.Line-1,
+				locRange.Begin.Column-1,
+				locRange.Begin.Line-1,
+				locRange.Begin.Column-1+len(bind.Variable),
+			)
+
+			symbols = append(symbols, protocol.DocumentSymbol{
+				Name:           string(bind.Variable),
+				Kind:           protocol.Variable,
+				Range:          resultRange,
+				SelectionRange: resultSelectionRange,
+				Detail:         symbolDetails(bind.Body),
+			})
+		}
+		symbols = append(symbols, buildDocumentSymbols(node.Body)...)
+	case *ast.DesugaredObject:
+		for _, field := range node.Fields {
+			kind := protocol.Field
+			if field.Hide == ast.ObjectFieldHidden {
+				kind = protocol.Property
+			}
+			fieldRange := processing.FieldToRange(&field)
+			symbols = append(symbols, protocol.DocumentSymbol{
+				Name:           field.Name.(*ast.LiteralString).Value,
+				Kind:           kind,
+				Range:          position.RangeASTToProtocol(fieldRange.FullRange),
+				SelectionRange: position.RangeASTToProtocol(fieldRange.SelectionRange),
+				Detail:         symbolDetails(field.Body),
+				Children:       buildDocumentSymbols(field.Body),
+			})
+		}
+	}
+
+	return symbols
+}
+
+func symbolDetails(node ast.Node) string {
+
+	switch node := node.(type) {
+	case *ast.Function:
+		var args []string
+		for _, param := range node.Parameters {
+			args = append(args, string(param.Name))
+		}
+		return fmt.Sprintf("Function(%s)", strings.Join(args, ", "))
+	case *ast.DesugaredObject:
+		return "Object"
+	case *ast.LiteralString:
+		return "String"
+	case *ast.LiteralNumber:
+		return "Number"
+	case *ast.LiteralBoolean:
+		return "Boolean"
+	case *ast.Import:
+		return "Import " + node.File.Value
+	case *ast.ImportStr:
+		return "Import " + node.File.Value
+	case *ast.Index:
+		return ""
+	}
+
+	return strings.TrimPrefix(reflect.TypeOf(node).String(), "*ast.")
+}

--- a/pkg/server/symbols.go
+++ b/pkg/server/symbols.go
@@ -16,11 +16,11 @@ import (
 func (s *server) DocumentSymbol(ctx context.Context, params *protocol.DocumentSymbolParams) ([]interface{}, error) {
 	doc, err := s.cache.get(params.TextDocument.URI)
 	if err != nil {
-		return nil, utils.LogErrorf("Definition: %s: %w", errorRetrievingDocument, err)
+		return nil, utils.LogErrorf("DocumentSymbol: %s: %w", errorRetrievingDocument, err)
 	}
 
 	if doc.ast == nil {
-		return nil, utils.LogErrorf("Definition: error parsing the document")
+		return nil, utils.LogErrorf("DocumentSymbol: error parsing the document")
 	}
 
 	symbols := buildDocumentSymbols(doc.ast)

--- a/pkg/server/symbols.go
+++ b/pkg/server/symbols.go
@@ -42,23 +42,12 @@ func buildDocumentSymbols(node ast.Node) []protocol.DocumentSymbol {
 		symbols = append(symbols, buildDocumentSymbols(node.Right)...)
 	case *ast.Local:
 		for _, bind := range node.Binds {
-			locRange := bind.LocRange
-			if !locRange.IsSet() {
-				locRange = *bind.Body.Loc()
-			}
-			resultRange := position.RangeASTToProtocol(locRange)
-			resultSelectionRange := position.NewProtocolRange(
-				locRange.Begin.Line-1,
-				locRange.Begin.Column-1,
-				locRange.Begin.Line-1,
-				locRange.Begin.Column-1+len(bind.Variable),
-			)
-
+			objectRange := processing.LocalBindToRange(&bind)
 			symbols = append(symbols, protocol.DocumentSymbol{
 				Name:           string(bind.Variable),
 				Kind:           protocol.Variable,
-				Range:          resultRange,
-				SelectionRange: resultSelectionRange,
+				Range:          position.RangeASTToProtocol(objectRange.FullRange),
+				SelectionRange: position.RangeASTToProtocol(objectRange.SelectionRange),
 				Detail:         symbolDetails(bind.Body),
 			})
 		}

--- a/pkg/server/symbols_test.go
+++ b/pkg/server/symbols_test.go
@@ -1,0 +1,205 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jdbaldry/go-language-server-protocol/lsp/protocol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSymbols(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		filename      string
+		expectSymbols []interface{}
+	}{
+		{
+			name:     "One field",
+			filename: "testdata/goto-comment.jsonnet",
+			expectSymbols: []interface{}{
+				protocol.DocumentSymbol{
+					Name:   "foo",
+					Detail: "String",
+					Kind:   protocol.Field,
+					Range: protocol.Range{
+						Start: protocol.Position{
+							Line:      2,
+							Character: 2,
+						},
+						End: protocol.Position{
+							Line:      2,
+							Character: 12,
+						},
+					},
+					SelectionRange: protocol.Range{
+						Start: protocol.Position{
+							Line:      2,
+							Character: 2,
+						},
+						End: protocol.Position{
+							Line:      2,
+							Character: 5,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "Two fields from plus root objects",
+			filename: "testdata/goto-basic-object.jsonnet",
+			expectSymbols: []interface{}{
+				protocol.DocumentSymbol{
+					Name:   "somevar",
+					Detail: "String",
+					Kind:   protocol.Variable,
+					Range: protocol.Range{
+						Start: protocol.Position{
+							Line:      0,
+							Character: 6,
+						},
+						End: protocol.Position{
+							Line:      0,
+							Character: 23,
+						},
+					},
+					SelectionRange: protocol.Range{
+						Start: protocol.Position{
+							Line:      0,
+							Character: 6,
+						},
+						End: protocol.Position{
+							Line:      0,
+							Character: 13,
+						},
+					},
+				},
+				protocol.DocumentSymbol{
+					Name:   "foo",
+					Detail: "String",
+					Kind:   protocol.Field,
+					Range: protocol.Range{
+						Start: protocol.Position{
+							Line:      3,
+							Character: 2,
+						},
+						End: protocol.Position{
+							Line:      3,
+							Character: 12,
+						},
+					},
+					SelectionRange: protocol.Range{
+						Start: protocol.Position{
+							Line:      3,
+							Character: 2,
+						},
+						End: protocol.Position{
+							Line:      3,
+							Character: 5,
+						},
+					},
+				},
+				protocol.DocumentSymbol{
+					Name:   "bar",
+					Detail: "String",
+					Kind:   protocol.Field,
+					Range: protocol.Range{
+						Start: protocol.Position{
+							Line:      5,
+							Character: 2,
+						},
+						End: protocol.Position{
+							Line:      5,
+							Character: 12,
+						},
+					},
+					SelectionRange: protocol.Range{
+						Start: protocol.Position{
+							Line:      5,
+							Character: 2,
+						},
+						End: protocol.Position{
+							Line:      5,
+							Character: 5,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "Functions",
+			filename: "testdata/goto-functions.libsonnet",
+			expectSymbols: []interface{}{
+				protocol.DocumentSymbol{
+					Name:   "myfunc",
+					Detail: "Function(arg1, arg2)",
+					Kind:   protocol.Variable,
+					Range: protocol.Range{
+						Start: protocol.Position{
+							Line:      0,
+							Character: 6,
+						},
+						End: protocol.Position{
+							Line:      3,
+							Character: 1,
+						},
+					},
+					SelectionRange: protocol.Range{
+						Start: protocol.Position{
+							Line:      0,
+							Character: 6,
+						},
+						End: protocol.Position{
+							Line:      0,
+							Character: 12,
+						},
+					},
+				},
+
+				protocol.DocumentSymbol{
+					Name:   "objFunc",
+					Detail: "Function(arg1, arg2, arg3)",
+					Kind:   protocol.Field,
+					Range: protocol.Range{
+						Start: protocol.Position{
+							Line:      6,
+							Character: 2,
+						},
+						End: protocol.Position{
+							Line:      11,
+							Character: 3,
+						},
+					},
+					SelectionRange: protocol.Range{
+						Start: protocol.Position{
+							Line:      6,
+							Character: 2,
+						},
+						End: protocol.Position{
+							Line:      6,
+							Character: 9,
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			params := &protocol.DocumentSymbolParams{
+				TextDocument: protocol.TextDocumentIdentifier{
+					URI: protocol.URIFromPath(tc.filename),
+				},
+			}
+
+			server := NewServer("any", "test version", nil, Configuration{
+				JPaths: []string{"testdata"},
+			})
+			serverOpenTestFile(t, server, string(tc.filename))
+			response, err := server.DocumentSymbol(context.Background(), params)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expectSymbols, response)
+		})
+	}
+}

--- a/pkg/server/symbols_test.go
+++ b/pkg/server/symbols_test.go
@@ -47,7 +47,7 @@ func TestSymbols(t *testing.T) {
 			},
 		},
 		{
-			name:     "Two fields from plus root objects",
+			name:     "local var + two fields from plus root objects",
 			filename: "testdata/goto-basic-object.jsonnet",
 			expectSymbols: []interface{}{
 				protocol.DocumentSymbol{

--- a/pkg/server/unused.go
+++ b/pkg/server/unused.go
@@ -12,10 +12,6 @@ func (s *server) Initialized(context.Context, *protocol.InitializedParams) error
 	return nil
 }
 
-func (s *server) DocumentSymbol(ctx context.Context, params *protocol.DocumentSymbolParams) ([]interface{}, error) {
-	return nil, nil
-}
-
 func (s *server) CodeAction(context.Context, *protocol.CodeActionParams) ([]protocol.CodeAction, error) {
 	return nil, notImplemented("CodeAction")
 }


### PR DESCRIPTION
Report symbols to clients of the language server
This allows features like the VSCode outline

In the following screenshots, see the tab in the lower left

![image](https://user-images.githubusercontent.com/29210090/187988334-08ae1d3d-c1ca-40fe-9430-6dda2f772375.png)
![image](https://user-images.githubusercontent.com/29210090/187988407-ed7eebfd-18f2-48cb-93c9-ddbaa012097f.png)
