### PR TITLE
Enable go-to-definition for computed field names.

### DIFF
--- a/pkg/ast_processing/find_position.go
+++ b/pkg/ast_processing/find_position.go
@@ -46,6 +46,7 @@ func FindNodeByPosition(node ast.Node, location ast.Location) (*nodestack.NodeSt
 					funcBody.LocRange = field.LocRange
 					stack.Push(funcBody)
 				} else {
+					stack.Push(field.Name)
 					stack.Push(body)
 				}
 			}

--- a/pkg/server/definition_test.go
+++ b/pkg/server/definition_test.go
@@ -723,6 +723,22 @@ var definitionTestCases = []definitionTestCase{
 			},
 		}},
 	},
+	{
+		name:     "goto computed field name object field",
+		filename: "testdata/goto-computed-field-names.jsonnet",
+		position: protocol.Position{Line: 3, Character: 9},
+		results: []definitionResult{{
+			targetFilename: "testdata/goto-computed-field-names.jsonnet",
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 0, Character: 14},
+				End:   protocol.Position{Line: 0, Character: 26},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 0, Character: 14},
+				End:   protocol.Position{Line: 0, Character: 17},
+			},
+		}},
+	},
 }
 
 func TestDefinition(t *testing.T) {

--- a/pkg/server/testdata/goto-computed-field-names.jsonnet
+++ b/pkg/server/testdata/goto-computed-field-names.jsonnet
@@ -1,0 +1,5 @@
+local obj = { bar: 'hello' };
+
+{
+  [obj.bar]: 'world!',
+}


### PR DESCRIPTION
When finding node by position, push `field.Name` to the search stack.
This allows us to now search through the field names as well when finding
definitions.