### PR TITLE
Use standard error pattern for `DocumentSymbol`, do not error out when parsing fails

### DIFF
--- a/pkg/server/definition.go
+++ b/pkg/server/definition.go
@@ -45,7 +45,7 @@ func (s *server) definitionLink(ctx context.Context, params *protocol.Definition
 	}
 
 	if doc.ast == nil {
-		return nil, utils.LogErrorf("Definition: error parsing the document")
+		return nil, utils.LogErrorf("Definition: %s", errorParsingDocument)
 	}
 
 	vm, err := s.getVM(doc.item.URI.SpanURI().Filename())

--- a/pkg/server/hover.go
+++ b/pkg/server/hover.go
@@ -21,7 +21,7 @@ func (s *server) Hover(ctx context.Context, params *protocol.HoverParams) (*prot
 
 	if doc.ast == nil {
 		// Hover triggers often. Throwing an error on each request is noisy
-		log.Error("Hover: error parsing the document")
+		log.Errorf("Hover: %s", errorParsingDocument)
 		return nil, nil
 	}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -31,6 +31,7 @@ import (
 
 const (
 	errorRetrievingDocument = "unable to retrieve document from the cache"
+	errorParsingDocument    = "error parsing the document"
 )
 
 // New returns a new language server.

--- a/pkg/server/symbols.go
+++ b/pkg/server/symbols.go
@@ -11,6 +11,7 @@ import (
 	position "github.com/grafana/jsonnet-language-server/pkg/position_conversion"
 	"github.com/grafana/jsonnet-language-server/pkg/utils"
 	"github.com/jdbaldry/go-language-server-protocol/lsp/protocol"
+	log "github.com/sirupsen/logrus"
 )
 
 func (s *server) DocumentSymbol(ctx context.Context, params *protocol.DocumentSymbolParams) ([]interface{}, error) {
@@ -20,7 +21,10 @@ func (s *server) DocumentSymbol(ctx context.Context, params *protocol.DocumentSy
 	}
 
 	if doc.ast == nil {
-		return nil, utils.LogErrorf("DocumentSymbol: error parsing the document")
+		// Returning an error too often can lead to the client killing the language server
+		// Logging the errors is sufficient
+		log.Errorf("DocumentSymbol: %s", errorParsingDocument)
+		return nil, nil
 	}
 
 	symbols := buildDocumentSymbols(doc.ast)


### PR DESCRIPTION
It's currently sending errors when DocumentSymbol fails to parse
This happens VERY often, causing the language server to kill itself