### PR TITLE
Basic go-to-definition inside functions

### DIFF
--- a/pkg/nodestack/nodestack.go
+++ b/pkg/nodestack/nodestack.go
@@ -55,6 +55,10 @@ func (s *NodeStack) BuildIndexList() []string {
 	for !s.IsEmpty() {
 		curr := s.Pop()
 		switch curr := curr.(type) {
+		case *ast.Apply:
+			if target, ok := curr.Target.(*ast.Var); ok {
+				indexList = append(indexList, string(target.Id))
+			}
 		case *ast.SuperIndex:
 			s.Push(curr.Index)
 			indexList = append(indexList, "super")

--- a/pkg/server/definition_test.go
+++ b/pkg/server/definition_test.go
@@ -739,6 +739,36 @@ var definitionTestCases = []definitionTestCase{
 			},
 		}},
 	},
+	{
+		name:     "goto field through function",
+		filename: "testdata/goto-functions-advanced.libsonnet",
+		position: protocol.Position{Line: 6, Character: 46},
+		results: []definitionResult{{
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 2, Character: 2},
+				End:   protocol.Position{Line: 2, Character: 12},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 2, Character: 2},
+				End:   protocol.Position{Line: 2, Character: 6},
+			},
+		}},
+	},
+	{
+		name:     "goto field through function-created object",
+		filename: "testdata/goto-functions-advanced.libsonnet",
+		position: protocol.Position{Line: 8, Character: 52},
+		results: []definitionResult{{
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 2, Character: 2},
+				End:   protocol.Position{Line: 2, Character: 12},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 2, Character: 2},
+				End:   protocol.Position{Line: 2, Character: 6},
+			},
+		}},
+	},
 }
 
 func TestDefinition(t *testing.T) {
@@ -837,7 +867,7 @@ func TestDefinitionFail(t *testing.T) {
 			name:     "goto range index fails",
 			filename: "testdata/goto-local-function.libsonnet",
 			position: protocol.Position{Line: 15, Character: 57},
-			expected: fmt.Errorf("unexpected node type when finding bind for 'ports'"),
+			expected: fmt.Errorf("unexpected node type when finding bind for 'ports': *ast.Apply"),
 		},
 		{
 			name:     "goto super fails as no LHS object exists",

--- a/pkg/server/testdata/goto-functions-advanced.libsonnet
+++ b/pkg/server/testdata/goto-functions-advanced.libsonnet
@@ -1,0 +1,10 @@
+local myfunc(arg1, arg2) = {
+  arg1: arg1,
+  arg2: arg2,
+};
+
+{
+  accessThroughFunc: myfunc('test', 'test').arg2,
+  funcCreatedObj: myfunc('test', 'test'),
+  accesThroughFuncCreatedObj: self.funcCreatedObj.arg2,
+}


### PR DESCRIPTION
When processing the index list, the language server will now go through function bodies to find fields
This will only occur when the function's body is directly a DesugaredObject
This doesn't support all cases. I will probably have to add more, I have already identified cases which are even more complex that do not work yet, but this is a good first step

In the `go-to-functions-advanced.libsonnet` file, this allows us to find the `arg2` field accessed later on, even though it's a field created by a function