### PR TITLE
Support symbols for computed fields

### DIFF
--- a/pkg/server/symbols.go
+++ b/pkg/server/symbols.go
@@ -64,7 +64,7 @@ func buildDocumentSymbols(node ast.Node) []protocol.DocumentSymbol {
 			}
 			fieldRange := processing.FieldToRange(&field)
 			symbols = append(symbols, protocol.DocumentSymbol{
-				Name:           field.Name.(*ast.LiteralString).Value,
+				Name:           processing.FieldNameToString(field.Name),
 				Kind:           kind,
 				Range:          position.RangeASTToProtocol(fieldRange.FullRange),
 				SelectionRange: position.RangeASTToProtocol(fieldRange.SelectionRange),

--- a/pkg/server/symbols_test.go
+++ b/pkg/server/symbols_test.go
@@ -184,6 +184,88 @@ func TestSymbols(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:     "Computed fields",
+			filename: "testdata/goto-computed-field-names.jsonnet",
+			expectSymbols: []interface{}{
+				protocol.DocumentSymbol{
+					Name:   "obj",
+					Detail: "Object",
+					Kind:   protocol.Variable,
+					Range: protocol.Range{
+						Start: protocol.Position{
+							Line:      0,
+							Character: 6,
+						},
+						End: protocol.Position{
+							Line:      0,
+							Character: 54,
+						},
+					},
+					SelectionRange: protocol.Range{
+						Start: protocol.Position{
+							Line:      0,
+							Character: 6,
+						},
+						End: protocol.Position{
+							Line:      0,
+							Character: 9,
+						},
+					},
+				},
+
+				protocol.DocumentSymbol{
+					Name:   "[obj.bar]",
+					Detail: "String",
+					Kind:   protocol.Field,
+					Range: protocol.Range{
+						Start: protocol.Position{
+							Line:      3,
+							Character: 2,
+						},
+						End: protocol.Position{
+							Line:      3,
+							Character: 21,
+						},
+					},
+					SelectionRange: protocol.Range{
+						Start: protocol.Position{
+							Line:      3,
+							Character: 2,
+						},
+						End: protocol.Position{
+							Line:      3,
+							Character: 11,
+						},
+					},
+				},
+				protocol.DocumentSymbol{
+					Name:   "[obj.nested.bar]",
+					Detail: "String",
+					Kind:   protocol.Field,
+					Range: protocol.Range{
+						Start: protocol.Position{
+							Line:      4,
+							Character: 2,
+						},
+						End: protocol.Position{
+							Line:      4,
+							Character: 28,
+						},
+					},
+					SelectionRange: protocol.Range{
+						Start: protocol.Position{
+							Line:      4,
+							Character: 2,
+						},
+						End: protocol.Position{
+							Line:      4,
+							Character: 18,
+						},
+					},
+				},
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			params := &protocol.DocumentSymbolParams{

--- a/pkg/server/testdata/goto-computed-field-names.jsonnet
+++ b/pkg/server/testdata/goto-computed-field-names.jsonnet
@@ -1,5 +1,6 @@
-local obj = { bar: 'hello' };
+local obj = { bar: 'hello', nested: { bar: 'hello' } };
 
 {
   [obj.bar]: 'world!',
+  [obj.nested.bar]: 'world!',
 }


### PR DESCRIPTION
Bug introduced in https://github.com/grafana/jsonnet-language-server/pull/60
The server currently panics while trying to get symbols when there's a computed field present
This will instead list the fields at `[field.content]` in symbols