### PR TITLE
On parse failure, keep the old AST

### DIFF
--- a/pkg/server/cache.go
+++ b/pkg/server/cache.go
@@ -12,7 +12,10 @@ import (
 type document struct {
 	// From DidOpen and DidChange
 	item protocol.TextDocumentItem
-	ast  ast.Node
+
+	// Contains the last succesfully parsed AST. If doc.err is not nil, it's out of date.
+	ast                  ast.Node
+	linesChangedSinceAST map[int]bool
 
 	// From diagnostics
 	val         string

--- a/pkg/server/definition.go
+++ b/pkg/server/definition.go
@@ -44,8 +44,12 @@ func (s *server) definitionLink(ctx context.Context, params *protocol.Definition
 		return nil, utils.LogErrorf("Definition: %s: %w", errorRetrievingDocument, err)
 	}
 
+	// Only find definitions, if the the line we're trying to find a definition for hasn't changed since last succesful AST parse
 	if doc.ast == nil {
-		return nil, utils.LogErrorf("Definition: %s", errorParsingDocument)
+		return nil, utils.LogErrorf("Definition: document was never successfully parsed, can't find definitions")
+	}
+	if doc.linesChangedSinceAST[int(params.Position.Line)] {
+		return nil, utils.LogErrorf("Definition: document line %d was changed since last successful parse, can't find definitions", params.Position.Line)
 	}
 
 	vm, err := s.getVM(doc.item.URI.SpanURI().Filename())

--- a/pkg/server/hover.go
+++ b/pkg/server/hover.go
@@ -19,7 +19,7 @@ func (s *server) Hover(ctx context.Context, params *protocol.HoverParams) (*prot
 		return nil, utils.LogErrorf("Hover: %s: %w", errorRetrievingDocument, err)
 	}
 
-	if doc.ast == nil {
+	if doc.err != nil {
 		// Hover triggers often. Throwing an error on each request is noisy
 		log.Errorf("Hover: %s", errorParsingDocument)
 		return nil, nil

--- a/pkg/server/symbols.go
+++ b/pkg/server/symbols.go
@@ -20,7 +20,7 @@ func (s *server) DocumentSymbol(ctx context.Context, params *protocol.DocumentSy
 		return nil, utils.LogErrorf("DocumentSymbol: %s: %w", errorRetrievingDocument, err)
 	}
 
-	if doc.ast == nil {
+	if doc.err != nil {
 		// Returning an error too often can lead to the client killing the language server
 		// Logging the errors is sufficient
 		log.Errorf("DocumentSymbol: %s", errorParsingDocument)


### PR DESCRIPTION
Also, add a new `linesChangedSinceAST` attribute to the cache. This new attribute contains all lines of a document which have changed since the AST was last parsed
This allows us to still use the AST when the file is changed (a WIP is a common use-case)
In order to reduce the amount of bad definitions in that case, go-to-definition is only active if the currently targeted line hasn't changed. Otherwise, it's all messed up

While this feature is slightly useful for go-to-definition, it'll be absolutely necessary for the completion feature I'm working on