### PR TITLE
Completion from dollar sign: Basic case

### DIFF
--- a/pkg/server/completion_test.go
+++ b/pkg/server/completion_test.go
@@ -285,6 +285,52 @@ func TestCompletion(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:            "autocomplete dollar sign",
+			filename:        "testdata/goto-dollar-simple.jsonnet",
+			replaceString:   "test: $.attribute,",
+			replaceByString: "test: $.",
+			expected: protocol.CompletionList{
+				IsIncomplete: false,
+				Items: []protocol.CompletionItem{
+					{
+						Label:      "attribute",
+						Kind:       protocol.FieldCompletion,
+						Detail:     "$.attribute",
+						InsertText: "attribute",
+					},
+					{
+						Label:      "attribute2",
+						Kind:       protocol.FieldCompletion,
+						Detail:     "$.attribute2",
+						InsertText: "attribute2",
+					},
+				},
+			},
+		},
+		{
+			name:            "autocomplete dollar sign, end with comma",
+			filename:        "testdata/goto-dollar-simple.jsonnet",
+			replaceString:   "test: $.attribute,",
+			replaceByString: "test: $.,",
+			expected: protocol.CompletionList{
+				IsIncomplete: false,
+				Items: []protocol.CompletionItem{
+					{
+						Label:      "attribute",
+						Kind:       protocol.FieldCompletion,
+						Detail:     "$.attribute",
+						InsertText: "attribute",
+					},
+					{
+						Label:      "attribute2",
+						Kind:       protocol.FieldCompletion,
+						Detail:     "$.attribute2",
+						InsertText: "attribute2",
+					},
+				},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Closes https://github.com/grafana/jsonnet-language-server/issues/4 

Also:
+ Sort the list of suggestions by label
+ Ignore lines ending with `,` or `;`. This happens when a user is replacing an index in an existing line (refactoring, etc)