### PR TITLE
Pull stdlib content from v0.19.0

### DIFF
--- a/pkg/stdlib/stdlib-content.jsonnet
+++ b/pkg/stdlib/stdlib-content.jsonnet
@@ -385,7 +385,7 @@ local html = import 'html.libsonnet';
         {
           name: 'splitLimitR',
           params: ['str', 'c', 'maxsplits'],
-          availableSince: 'upcoming',
+          availableSince: 'v0.19.0',
           description: 'As <code>std.splitLimit(str, c, maxsplits)</code> but will split from right to left.',
           examples: [
             {
@@ -1286,7 +1286,7 @@ local html = import 'html.libsonnet';
         {
           name: 'all',
           params: ['arr'],
-          availableSince: 'upcoming',
+          availableSince: 'v0.19.0',
           description: html.paragraphs([
             |||
               Return true if all elements of <code>arr</code> is true, false otherwise. <code>all([])</code> evaluates to true.
@@ -1299,7 +1299,7 @@ local html = import 'html.libsonnet';
         {
           name: 'any',
           params: ['arr'],
-          availableSince: 'upcoming',
+          availableSince: 'v0.19.0',
           description: html.paragraphs([
             |||
               Return true if any element of <code>arr</code> is true, false otherwise. <code>any([])</code> evaluates to false.


### PR DESCRIPTION
This should add the `splitLimitR`, `all` and `any` functions to autocomplete + hover