### PR TITLE
Update the sha256 sum for vendored go modules

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -9,7 +9,7 @@ buildGoModule rec {
     -X main.version=${version}
   '';
   src = lib.cleanSource ../.;
-  vendorSha256 = "sha256-imFr4N/YmpwjVZSCBHG7cyJt4RKTn+T7VPdL8R/ba5o=";
+  vendorSha256 = "sha256-ZyTo79M5nqtqrtTOGanzgHcnSvqCKACacNBWzhYG5nY=";
 
   meta = with lib; {
     description = "A Language Server Protocol server for Jsonnet";


### PR DESCRIPTION
Builds are failing because there is a mismatch in the vendoring required for `go build` and the vendoring that results from the vendorSha256 fixed output derivation. 


Signed-off-by: Jack Baldry <jack.baldry@grafana.com>