### PR TITLE
Add label when completing a nested index

### DIFF
--- a/pkg/server/completion.go
+++ b/pkg/server/completion.go
@@ -205,6 +205,8 @@ func typeToString(t ast.Node) string {
 		return "string"
 	case *ast.Import, *ast.ImportStr:
 		return "import"
+	case *ast.Index:
+		return "object field"
 	}
 	return reflect.TypeOf(t).String()
 }


### PR DESCRIPTION
When doing auto-complete, it currently shows `*ast.Index` when it's nested Indexing because we don't follow up to the final ref 
Instead of `ast.Index`, we can say `object field` which makes a bit more sense for users