### PR TITLE
update vendor sha signature and bump version in flake

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -3,13 +3,13 @@
 with pkgs;
 buildGoModule rec {
   pname = "jsonnet-language-server";
-  version = "0.12.0";
+  version = "0.13.0";
 
   ldflags = ''
     -X main.version=${version}
   '';
   src = lib.cleanSource ../.;
-  vendorSha256 = "sha256-lC3GAOJ/XVzn+9kk4PnW/7UwqjiXP7DqYmqauwOqQ+k=";
+  vendorSha256 = "/mfwBHaouYN8JIxPz720/7MlMVh+5EEB+ocnYe4B020=";
 
   meta = with lib; {
     description = "A Language Server Protocol server for Jsonnet";


### PR DESCRIPTION
This PR updates the version of the flake to match latest and updates the sha of vendored dependencies to match as well.