### PR TITLE
Fix world's slowest stack overflow

### DIFF
--- a/pkg/ast/processing/find_field.go
+++ b/pkg/ast/processing/find_field.go
@@ -15,7 +15,6 @@ func FindRangesFromIndexList(stack *nodestack.NodeStack, indexList []string, vm 
 	var foundDesugaredObjects []*ast.DesugaredObject
 	// First element will be super, self, or var name
 	start, indexList := indexList[0], indexList[1:]
-	sameFileOnly := false
 	switch {
 	case start == "super":
 		// Find the LHS desugared object of a binary node
@@ -36,7 +35,6 @@ func FindRangesFromIndexList(stack *nodestack.NodeStack, indexList []string, vm 
 	case start == "std":
 		return nil, fmt.Errorf("cannot get definition of std lib")
 	case start == "$":
-		sameFileOnly = true
 		foundDesugaredObjects = FindTopLevelObjects(nodestack.NewNodeStack(stack.From), vm)
 	case strings.Contains(start, "."):
 		foundDesugaredObjects = FindTopLevelObjectsInFile(vm, start, "")
@@ -64,10 +62,8 @@ func FindRangesFromIndexList(stack *nodestack.NodeStack, indexList []string, vm 
 			tmpStack := nodestack.NewNodeStack(stack.From)
 			foundDesugaredObjects = FindTopLevelObjects(tmpStack, vm)
 		case *ast.Import:
-			if !sameFileOnly {
-				filename := bodyNode.File.Value
-				foundDesugaredObjects = FindTopLevelObjectsInFile(vm, filename, "")
-			}
+			filename := bodyNode.File.Value
+			foundDesugaredObjects = FindTopLevelObjectsInFile(vm, filename, "")
 
 		case *ast.Index, *ast.Apply:
 			tempStack := nodestack.NewNodeStack(bodyNode)

--- a/pkg/ast/processing/find_field.go
+++ b/pkg/ast/processing/find_field.go
@@ -64,8 +64,11 @@ func FindRangesFromIndexList(stack *nodestack.NodeStack, indexList []string, vm 
 			tmpStack := nodestack.NewNodeStack(stack.From)
 			foundDesugaredObjects = FindTopLevelObjects(tmpStack, vm)
 		case *ast.Import:
-			filename := bodyNode.File.Value
-			foundDesugaredObjects = FindTopLevelObjectsInFile(vm, filename, "")
+			if !sameFileOnly {
+				filename := bodyNode.File.Value
+				foundDesugaredObjects = FindTopLevelObjectsInFile(vm, filename, "")
+			}
+
 		case *ast.Index, *ast.Apply:
 			tempStack := nodestack.NewNodeStack(bodyNode)
 			indexList = append(tempStack.BuildIndexList(), indexList...)
@@ -80,10 +83,10 @@ func FindRangesFromIndexList(stack *nodestack.NodeStack, indexList []string, vm 
 		}
 	}
 
-	return extractObjectRangesFromDesugaredObjs(stack, vm, foundDesugaredObjects, sameFileOnly, indexList, partialMatchFields)
+	return extractObjectRangesFromDesugaredObjs(vm, foundDesugaredObjects, indexList, partialMatchFields)
 }
 
-func extractObjectRangesFromDesugaredObjs(stack *nodestack.NodeStack, vm *jsonnet.VM, desugaredObjs []*ast.DesugaredObject, sameFileOnly bool, indexList []string, partialMatchFields bool) ([]ObjectRange, error) {
+func extractObjectRangesFromDesugaredObjs(vm *jsonnet.VM, desugaredObjs []*ast.DesugaredObject, indexList []string, partialMatchFields bool) ([]ObjectRange, error) {
 	var ranges []ObjectRange
 	for len(indexList) > 0 {
 		index := indexList[0]
@@ -135,10 +138,15 @@ func extractObjectRangesFromDesugaredObjs(stack *nodestack.NodeStack, vm *jsonne
 			case *ast.DesugaredObject:
 				desugaredObjs = append(desugaredObjs, fieldNode)
 			case *ast.Index:
-				additionalIndexList := append(nodestack.NewNodeStack(fieldNode).BuildIndexList(), indexList...)
-				result, err := FindRangesFromIndexList(stack, additionalIndexList, vm, partialMatchFields)
-				if len(result) > 0 {
-					if !sameFileOnly || result[0].Filename == stack.From.Loc().FileName {
+				// if we're trying to find the a definition which is an index,
+				// we need to find it from itself, meaning that we need to create a stack
+				// from the index's target and search from there
+				rootNode, _, _ := vm.ImportAST("", fieldNode.LocRange.FileName)
+				stack, _ := FindNodeByPosition(rootNode, fieldNode.Target.Loc().Begin)
+				if stack != nil {
+					additionalIndexList := append(nodestack.NewNodeStack(fieldNode).BuildIndexList(), indexList...)
+					result, _ := FindRangesFromIndexList(stack, additionalIndexList, vm, partialMatchFields)
+					if len(result) > 0 {
 						return result, err
 					}
 				}

--- a/pkg/server/definition_test.go
+++ b/pkg/server/definition_test.go
@@ -910,6 +910,22 @@ var definitionTestCases = []definitionTestCase{
 			},
 		}},
 	},
+	{
+		name:     "test fix infinite recursion",
+		filename: "./testdata/goto-infinite-recursion-bug-1.jsonnet",
+		position: protocol.Position{Line: 2, Character: 26},
+		results: []definitionResult{{
+			targetFilename: "testdata/goto-infinite-recursion-bug-3.libsonnet",
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 5, Character: 10},
+				End:   protocol.Position{Line: 5, Character: 36},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 5, Character: 10},
+				End:   protocol.Position{Line: 5, Character: 22},
+			},
+		}},
+	},
 }
 
 func TestDefinition(t *testing.T) {

--- a/pkg/server/testdata/goto-infinite-recursion-bug-1.jsonnet
+++ b/pkg/server/testdata/goto-infinite-recursion-bug-1.jsonnet
@@ -1,0 +1,6 @@
+local drone = import './goto-infinite-recursion-bug-2.libsonnet';
+{
+  steps: drone.step.withCommands([
+    'blabla',
+  ]),
+}

--- a/pkg/server/testdata/goto-infinite-recursion-bug-2.libsonnet
+++ b/pkg/server/testdata/goto-infinite-recursion-bug-2.libsonnet
@@ -1,0 +1,15 @@
+local drone = import './goto-infinite-recursion-bug-3.libsonnet';
+{
+  pipeline:
+    drone.pipeline.docker {
+      new(name):
+        super.new(name)
+        + super.clone.withRetries(3)
+        + super.clone.withDepth(10000)
+        + super.platform.withArch('amd64')
+        + super.withImagePullSecrets(['dockerconfigjson']),
+    },
+
+  step:
+    drone.pipeline.docker.step,
+}

--- a/pkg/server/testdata/goto-infinite-recursion-bug-3.libsonnet
+++ b/pkg/server/testdata/goto-infinite-recursion-bug-3.libsonnet
@@ -1,0 +1,13 @@
+local lib =
+  {
+    pipeline: {
+      docker: {
+        step: {
+          withCommands(commands): {},
+        },
+      },
+    },
+  };
+
+
+lib


### PR DESCRIPTION
When dealing with CRDsonnet libraries in our (Grafana Labs) repositories, the language server would lock up and use up all my CPU:

- I thought it had something to do with CRDsonnet but I was wrong.
- This happened because it was trying to find a field in the wrong nodestack repeatedly (see image). It didn't crash because it didn't loop quick enough?
- This PR fixes the issue.
- Obviously, the language server can't find fields that come from processing jsonschema, but at least it doesn't take up 4 full CPUs (it reached 1% CPU usage while testing :) )

![image](https://github.com/grafana/jsonnet-language-server/assets/29210090/7e6c9ef6-fbbc-4bc6-aaac-9c6586826691)
