### PR TITLE
Send settings on client initialization

### DIFF
--- a/editor/emacs/jsonnet-language-server.el
+++ b/editor/emacs/jsonnet-language-server.el
@@ -18,6 +18,11 @@
  (make-lsp-client
   :new-connection (lsp-stdio-connection (lambda () lsp-jsonnet-executable))
   :activation-fn (lsp-activate-on "jsonnet")
+  :initialized-fn (lambda (workspace)
+                    (with-lsp-workspace workspace
+                      (lsp--set-configuration
+                       ;; TODO: jsonnet-language-server settings should use a prefix
+                       (ht-get (lsp-configuration-section "jsonnet") "jsonnet"))))
   :server-id 'jsonnet))
 
 ;; Start the language server whenever jsonnet-mode is used.


### PR DESCRIPTION
Send settings on LSP client initialization.  Note jsonnet-language-server is unusual and expects configuration without a prefix.  This is probably a bug in jsonnet-language-server, but this PR works with the existing code by passing through the "jsonnet" settings subtree, without the "jsonnet" prefix.

Example:
```elisp
;; .emacs
(lsp-register-custom-settings
 '(("jsonnet.formatting"
   ;; jsonnetfmt --string-style d --comment-style s
   ((StringStyle . "double")
    (CommentStyle . "slash")))))
```