### PR TITLE
Fix: Go-to definition on recursive binary operators

### DIFF
--- a/pkg/ast/processing/find_field.go
+++ b/pkg/ast/processing/find_field.go
@@ -162,10 +162,10 @@ func extractObjectRangesFromDesugaredObjs(vm *jsonnet.VM, desugaredObjs []*ast.D
 }
 
 func flattenBinary(node ast.Node) []ast.Node {
-	if _, nodeIsBinary := node.(*ast.Binary); !nodeIsBinary {
+	binary, nodeIsBinary := node.(*ast.Binary)
+	if !nodeIsBinary {
 		return []ast.Node{node}
 	}
-	binary := node.(*ast.Binary)
 	return append(flattenBinary(binary.Right), flattenBinary(binary.Left)...)
 }
 

--- a/pkg/ast/processing/find_field.go
+++ b/pkg/ast/processing/find_field.go
@@ -161,6 +161,14 @@ func extractObjectRangesFromDesugaredObjs(vm *jsonnet.VM, desugaredObjs []*ast.D
 	return ranges, nil
 }
 
+func flattenBinary(node ast.Node) []ast.Node {
+	if _, nodeIsBinary := node.(*ast.Binary); !nodeIsBinary {
+		return []ast.Node{node}
+	}
+	binary := node.(*ast.Binary)
+	return append(flattenBinary(binary.Right), flattenBinary(binary.Left)...)
+}
+
 // unpackFieldNodes extracts nodes from fields
 // - Binary nodes. A field could be either in the left or right side of the binary
 // - Self nodes. We want the object self refers to, not the self node itself
@@ -182,8 +190,7 @@ func unpackFieldNodes(vm *jsonnet.VM, fields []*ast.DesugaredObjectField) ([]ast
 				}
 			}
 		case *ast.Binary:
-			fieldNodes = append(fieldNodes, fieldNode.Right)
-			fieldNodes = append(fieldNodes, fieldNode.Left)
+			fieldNodes = append(fieldNodes, flattenBinary(fieldNode)...)
 		default:
 			fieldNodes = append(fieldNodes, fieldNode)
 		}

--- a/pkg/server/definition_test.go
+++ b/pkg/server/definition_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	_ "embed"
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/jdbaldry/go-language-server-protocol/lsp/protocol"
@@ -926,6 +927,22 @@ var definitionTestCases = []definitionTestCase{
 			},
 		}},
 	},
+	{
+		name:     "grafonnet: eval variable selection options",
+		filename: "./testdata/grafonnet/eval-variable-options.jsonnet",
+		position: protocol.Position{Line: 5, Character: 54},
+		results: []definitionResult{{
+			targetFilename: "testdata/grafonnet/vendor/github.com/grafana/grafonnet/gen/grafonnet-v10.0.0/custom/dashboard/variable.libsonnet",
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 101, Character: 12},
+				End:   protocol.Position{Line: 103, Character: 13},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 101, Character: 12},
+				End:   protocol.Position{Line: 101, Character: 21},
+			},
+		}},
+	},
 }
 
 func TestDefinition(t *testing.T) {
@@ -941,7 +958,7 @@ func TestDefinition(t *testing.T) {
 			}
 
 			server := NewServer("any", "test version", nil, Configuration{
-				JPaths: []string{"testdata"},
+				JPaths: []string{"testdata", filepath.Join(filepath.Dir(tc.filename), "vendor")},
 			})
 			serverOpenTestFile(t, server, tc.filename)
 			response, err := server.definitionLink(params)

--- a/pkg/server/testdata/grafonnet/eval-variable-options.jsonnet
+++ b/pkg/server/testdata/grafonnet/eval-variable-options.jsonnet
@@ -1,0 +1,7 @@
+local g = import 'github.com/grafana/grafonnet/gen/grafonnet-v10.0.0/main.libsonnet';
+
+g.dashboard.new('title')
++ g.dashboard.withVariables([
+  g.dashboard.variable.custom.new('var', ['a'])
+  + g.dashboard.variable.custom.selectionOptions.withMulti(),
+])


### PR DESCRIPTION
Depends on https://github.com/grafana/jsonnet-language-server/pull/127

It was only looking through a single level of binaries, so the following didn't work:

`obj1 + obj2 + obj3` which in the AST is:

binary(binary(obj1, obj2), obj3)