### PR TITLE
nix: update to 0.13.1 and remove deprecated vendorSha256

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -3,18 +3,18 @@
 with pkgs;
 buildGoModule rec {
   pname = "jsonnet-language-server";
-  version = "0.13.0";
+  version = "0.13.1";
 
   ldflags = ''
     -X main.version=${version}
   '';
   src = lib.cleanSource ../.;
-  vendorSha256 = "/mfwBHaouYN8JIxPz720/7MlMVh+5EEB+ocnYe4B020=";
+  vendorHash = "sha256-+9Eh40kkyZc9mS4m6BqK5PweFRUA0iWgsG/h2jZJr5w=";
 
   meta = with lib; {
     description = "A Language Server Protocol server for Jsonnet";
     homepage = "https://github.com/grafana/jsonnet-language-server";
     license = licenses.agpl3;
-    maintainers = with maintainers; [ jdbaldry ];
+    maintainers = with maintainers; [ jdbaldry trevorwhitney ];
   };
 }

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -17,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1661720780,
-        "narHash": "sha256-AJNGyaB2eKZAYaPNjBZOzap87yL+F9ZLaFzzMkvega0=",
+        "lastModified": 1704722960,
+        "narHash": "sha256-mKGJ3sPsT6//s+Knglai5YflJUF2DGj7Ai6Ynopz0kI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a63021a330d8d33d862a8e29924b42d73037dd37",
+        "rev": "317484b1ead87b9c1b8ac5261a8d2dd748a0492d",
         "type": "github"
       },
       "original": {
@@ -35,6 +38,21 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -7,12 +7,10 @@
   outputs = { self, nixpkgs, flake-utils }:
     {
       overlay =
-        (
-          final: prev: {
-            jsonnet-language-server = prev.callPackage ./default.nix { pkgs = prev; };
-            snitch = prev.callPackage ./snitch.nix { pkgs = prev; };
-          }
-        );
+        final: prev: {
+          jsonnet-language-server = prev.callPackage ./default.nix { pkgs = prev; };
+          snitch = prev.callPackage ./snitch.nix { pkgs = prev; };
+        };
     } // (
       flake-utils.lib.eachDefaultSystem (
         system:

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -7,6 +7,7 @@ mkShell {
     go_1_19
     golangci-lint
     gopls
+    jsonnet-language-server
     nix-prefetch
     snitch
   ];

--- a/nix/snitch.nix
+++ b/nix/snitch.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
     rev = version;
     sha256 = "sha256-bflHSWN/BH4TSTTP4M3DldVwkV8MUSVCO15eYJTtTi0=";
   };
-  vendorSha256 = "sha256-QAbxld0UY7jO9ommX7VrPKOWEiFPmD/xw02EZL6628A=";
+  vendorHash = "sha256-QAbxld0UY7jO9ommX7VrPKOWEiFPmD/xw02EZL6628A=";
 
   meta = with lib; {
     description = "Language agnostic tool that collects TODOs in the source code and reports them as Issues";


### PR DESCRIPTION
bumps the jsonnet-language-server version to the latest (0.13.1) and removes the deprecated `vendorSha256` properties from the nix derivations/packages (replacing with `vendorHash`)