### PR TITLE
Support `assert` statements

### DIFF
--- a/pkg/ast/processing/find_position.go
+++ b/pkg/ast/processing/find_position.go
@@ -57,6 +57,9 @@ func FindNodeByPosition(node ast.Node, location ast.Location) (*nodestack.NodeSt
 			for _, local := range curr.Locals {
 				stack.Push(local.Body)
 			}
+			for _, assert := range curr.Asserts {
+				stack.Push(assert)
+			}
 		case *ast.Binary:
 			stack.Push(curr.Left)
 			stack.Push(curr.Right)
@@ -94,6 +97,9 @@ func FindNodeByPosition(node ast.Node, location ast.Location) (*nodestack.NodeSt
 			stack.Push(curr.Index)
 		case *ast.Unary:
 			stack.Push(curr.Expr)
+		case *ast.Assert:
+			stack.Push(curr.Cond)
+			stack.Push(curr.Message)
 		}
 	}
 	return searchStack.ReorderDesugaredObjects(), nil

--- a/pkg/server/definition_test.go
+++ b/pkg/server/definition_test.go
@@ -943,6 +943,36 @@ var definitionTestCases = []definitionTestCase{
 			},
 		}},
 	},
+	{
+		name:     "goto assert local var",
+		filename: "testdata/goto-assert-var.jsonnet",
+		position: protocol.Position{Line: 3, Character: 11},
+		results: []definitionResult{{
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 1, Character: 8},
+				End:   protocol.Position{Line: 1, Character: 19},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 1, Character: 8},
+				End:   protocol.Position{Line: 1, Character: 12},
+			},
+		}},
+	},
+	{
+		name:     "goto assert self var",
+		filename: "testdata/goto-assert-var.jsonnet",
+		position: protocol.Position{Line: 3, Character: 23},
+		results: []definitionResult{{
+			targetRange: protocol.Range{
+				Start: protocol.Position{Line: 2, Character: 2},
+				End:   protocol.Position{Line: 2, Character: 16},
+			},
+			targetSelectionRange: protocol.Range{
+				Start: protocol.Position{Line: 2, Character: 2},
+				End:   protocol.Position{Line: 2, Character: 6},
+			},
+		}},
+	},
 }
 
 func TestDefinition(t *testing.T) {

--- a/pkg/server/testdata/goto-assert-var.jsonnet
+++ b/pkg/server/testdata/goto-assert-var.jsonnet
@@ -1,0 +1,5 @@
+{
+  local var1 = true,
+  var2: 'string',
+  assert var1 : self.var2,
+}


### PR DESCRIPTION
Also refactored `FindNodeByPosition`: All the function does is find the children of nodes, `go-jsonnet` has a helper for that

Closes https://github.com/grafana/jsonnet-language-server/issues/128