### PR TITLE
Auto-complete function body attributes

### DIFF
--- a/pkg/ast/processing/find_field.go
+++ b/pkg/ast/processing/find_field.go
@@ -40,6 +40,11 @@ func FindRangesFromIndexList(stack *nodestack.NodeStack, indexList []string, vm 
 		foundDesugaredObjects = FindTopLevelObjectsInFile(vm, start, "")
 
 	default:
+		if strings.Count(start, "(") == 1 && strings.Count(start, ")") == 1 {
+			// If the index is a function call, we need to find the function definition
+			// We can ignore the arguments. We'll only consider static attributes from the function's body
+			start = strings.Split(start, "(")[0]
+		}
 		// Get ast.DesugaredObject at variable definition by getting bind then setting ast.DesugaredObject
 		bind := FindBindByIDViaStack(stack, ast.Identifier(start))
 		if bind == nil {

--- a/pkg/server/completion_test.go
+++ b/pkg/server/completion_test.go
@@ -663,6 +663,35 @@ func TestCompletion(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:            "complete attribute from function",
+			filename:        "testdata/goto-functions.libsonnet",
+			replaceString:   "test: myfunc(arg1, arg2)",
+			replaceByString: "test: myfunc(arg1, arg2).",
+			expected: protocol.CompletionList{
+				IsIncomplete: false,
+				Items: []protocol.CompletionItem{
+					{
+						Label:      "atb1",
+						Kind:       protocol.FieldCompletion,
+						Detail:     "myfunc(arg1, arg2).atb1",
+						InsertText: "atb1",
+						LabelDetails: protocol.CompletionItemLabelDetails{
+							Description: "variable",
+						},
+					},
+					{
+						Label:      "atb2",
+						Kind:       protocol.FieldCompletion,
+						Detail:     "myfunc(arg1, arg2).atb2",
+						InsertText: "atb2",
+						LabelDetails: protocol.CompletionItemLabelDetails{
+							Description: "variable",
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/server/testdata/goto-functions.libsonnet
+++ b/pkg/server/testdata/goto-functions.libsonnet
@@ -1,6 +1,6 @@
 local myfunc(arg1, arg2) = {
-  arg1: arg1,
-  arg2: arg2,
+  atb1: arg1,
+  atb2: arg2,
 };
 
 {


### PR DESCRIPTION
Closes https://github.com/grafana/jsonnet-language-server/issues/129 
Had to implement a more sophisticated word-splitting function because `myfunc(arg1, arg2) has to be a single "word"