### PR TITLE
Global cache for documents + top level jsonnet objects

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -1,14 +1,13 @@
 [linters]
 enable = [
+  "copyloopvar",
   "dogsled",
-  "exportloopref",
   "forcetypeassert",
   "goconst",
   "gocritic",
   "gocyclo",
   "goimports",
   "goprintffuncname",
-  "gosec",
   "gosimple",
   "govet",
   "ineffassign",

--- a/pkg/ast/processing/find_field.go
+++ b/pkg/ast/processing/find_field.go
@@ -219,7 +219,6 @@ func findObjectFieldsInObject(objectNode *ast.DesugaredObject, index string, par
 
 	var matchingFields []*ast.DesugaredObjectField
 	for _, field := range objectNode.Fields {
-		field := field
 		literalString, isString := field.Name.(*ast.LiteralString)
 		if !isString {
 			continue

--- a/pkg/ast/processing/processor.go
+++ b/pkg/ast/processing/processor.go
@@ -1,0 +1,18 @@
+package processing
+
+import (
+	"github.com/google/go-jsonnet"
+	"github.com/grafana/jsonnet-language-server/pkg/cache"
+)
+
+type Processor struct {
+	cache *cache.Cache
+	vm    *jsonnet.VM
+}
+
+func NewProcessor(cache *cache.Cache, vm *jsonnet.VM) *Processor {
+	return &Processor{
+		cache: cache,
+		vm:    vm,
+	}
+}

--- a/pkg/ast/processing/top_level_objects.go
+++ b/pkg/ast/processing/top_level_objects.go
@@ -1,25 +1,23 @@
 package processing
 
 import (
-	"github.com/google/go-jsonnet"
 	"github.com/google/go-jsonnet/ast"
-	"github.com/grafana/jsonnet-language-server/pkg/cache"
 	"github.com/grafana/jsonnet-language-server/pkg/nodestack"
 	log "github.com/sirupsen/logrus"
 )
 
-func FindTopLevelObjectsInFile(cache *cache.Cache, vm *jsonnet.VM, filename, importedFrom string) []*ast.DesugaredObject {
-	v, ok := cache.GetTopLevelObject(filename, importedFrom)
+func (p *Processor) FindTopLevelObjectsInFile(filename, importedFrom string) []*ast.DesugaredObject {
+	v, ok := p.cache.GetTopLevelObject(filename, importedFrom)
 	if !ok {
-		rootNode, _, _ := vm.ImportAST(importedFrom, filename)
-		v = FindTopLevelObjects(cache, nodestack.NewNodeStack(rootNode), vm)
-		cache.PutTopLevelObject(filename, importedFrom, v)
+		rootNode, _, _ := p.vm.ImportAST(importedFrom, filename)
+		v = p.FindTopLevelObjects(nodestack.NewNodeStack(rootNode))
+		p.cache.PutTopLevelObject(filename, importedFrom, v)
 	}
 	return v
 }
 
 // Find all ast.DesugaredObject's from NodeStack
-func FindTopLevelObjects(cache *cache.Cache, stack *nodestack.NodeStack, vm *jsonnet.VM) []*ast.DesugaredObject {
+func (p *Processor) FindTopLevelObjects(stack *nodestack.NodeStack) []*ast.DesugaredObject {
 	var objects []*ast.DesugaredObject
 	for !stack.IsEmpty() {
 		curr := stack.Pop()
@@ -33,7 +31,7 @@ func FindTopLevelObjects(cache *cache.Cache, stack *nodestack.NodeStack, vm *jso
 			stack.Push(curr.Body)
 		case *ast.Import:
 			filename := curr.File.Value
-			rootNode, _, _ := vm.ImportAST(string(curr.Loc().File.DiagnosticFileName), filename)
+			rootNode, _, _ := p.vm.ImportAST(string(curr.Loc().File.DiagnosticFileName), filename)
 			stack.Push(rootNode)
 		case *ast.Index:
 			indexValue, indexIsString := curr.Index.(*ast.LiteralString)
@@ -44,7 +42,7 @@ func FindTopLevelObjects(cache *cache.Cache, stack *nodestack.NodeStack, vm *jso
 			var container ast.Node
 			// If our target is a var, the container for the index is the var ref
 			if varTarget, targetIsVar := curr.Target.(*ast.Var); targetIsVar {
-				ref, err := FindVarReference(varTarget, vm)
+				ref, err := p.FindVarReference(varTarget)
 				if err != nil {
 					log.WithError(err).Errorf("Error finding var reference, ignoring this node")
 					continue
@@ -61,7 +59,7 @@ func FindTopLevelObjects(cache *cache.Cache, stack *nodestack.NodeStack, vm *jso
 			if containerObj, containerIsObj := container.(*ast.DesugaredObject); containerIsObj {
 				possibleObjects = []*ast.DesugaredObject{containerObj}
 			} else if containerImport, containerIsImport := container.(*ast.Import); containerIsImport {
-				possibleObjects = FindTopLevelObjectsInFile(cache, vm, containerImport.File.Value, string(containerImport.Loc().File.DiagnosticFileName))
+				possibleObjects = p.FindTopLevelObjectsInFile(containerImport.File.Value, string(containerImport.Loc().File.DiagnosticFileName))
 			}
 
 			for _, obj := range possibleObjects {
@@ -70,7 +68,7 @@ func FindTopLevelObjects(cache *cache.Cache, stack *nodestack.NodeStack, vm *jso
 				}
 			}
 		case *ast.Var:
-			varReference, err := FindVarReference(curr, vm)
+			varReference, err := p.FindVarReference(curr)
 			if err != nil {
 				log.WithError(err).Errorf("Error finding var reference, ignoring this node")
 				continue

--- a/pkg/server/completion.go
+++ b/pkg/server/completion.go
@@ -84,7 +84,8 @@ func (s *Server) completionFromStack(line string, stack *nodestack.NodeStack, vm
 		return items
 	}
 
-	ranges, err := processing.FindRangesFromIndexList(s.cache, stack, indexes, vm, true)
+	processor := processing.NewProcessor(s.cache, vm)
+	ranges, err := processor.FindRangesFromIndexList(stack, indexes, true)
 	if err != nil {
 		log.Errorf("Completion: error finding ranges: %v", err)
 		return []protocol.CompletionItem{}

--- a/pkg/server/configuration_test.go
+++ b/pkg/server/configuration_test.go
@@ -141,10 +141,10 @@ func TestConfiguration(t *testing.T) {
 
 			vm := s.getVM("any")
 
-			doc, err := s.cache.get(fileURI)
+			doc, err := s.cache.Get(fileURI)
 			assert.NoError(t, err)
 
-			json, err := vm.Evaluate(doc.ast)
+			json, err := vm.Evaluate(doc.AST)
 			assert.NoError(t, err)
 			assert.JSONEq(t, tc.expectedFileOutput, json)
 		})

--- a/pkg/server/definition.go
+++ b/pkg/server/definition.go
@@ -63,6 +63,7 @@ func (s *Server) definitionLink(params *protocol.DefinitionParams) ([]protocol.D
 
 func (s *Server) findDefinition(root ast.Node, params *protocol.DefinitionParams, vm *jsonnet.VM) ([]protocol.DefinitionLink, error) {
 	var response []protocol.DefinitionLink
+	processor := processing.NewProcessor(s.cache, vm)
 
 	searchStack, _ := processing.FindNodeByPosition(root, position.ProtocolToAST(params.Position))
 	deepestNode := searchStack.Pop()
@@ -93,7 +94,7 @@ func (s *Server) findDefinition(root ast.Node, params *protocol.DefinitionParams
 		indexSearchStack := nodestack.NewNodeStack(deepestNode)
 		indexList := indexSearchStack.BuildIndexList()
 		tempSearchStack := *searchStack
-		objectRanges, err := processing.FindRangesFromIndexList(s.cache, &tempSearchStack, indexList, vm, false)
+		objectRanges, err := processor.FindRangesFromIndexList(&tempSearchStack, indexList, false)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/server/diagnostics_test.go
+++ b/pkg/server/diagnostics_test.go
@@ -57,7 +57,7 @@ local unused = 'test';
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			s, fileURI := testServerWithFile(t, nil, tc.fileContent)
-			doc, err := s.cache.get(fileURI)
+			doc, err := s.cache.Get(fileURI)
 			if err != nil {
 				t.Fatalf("%s: %v", errorRetrievingDocument, err)
 			}
@@ -145,7 +145,7 @@ func TestGetEvalDiags(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			s, fileURI := testServerWithFile(t, nil, tc.fileContent)
-			doc, err := s.cache.get(fileURI)
+			doc, err := s.cache.Get(fileURI)
 			if err != nil {
 				t.Fatalf("%s: %v", errorRetrievingDocument, err)
 			}

--- a/pkg/server/execute.go
+++ b/pkg/server/execute.go
@@ -43,12 +43,12 @@ func (s *Server) evalItem(params *protocol.ExecuteCommandParams) (interface{}, e
 		return nil, fmt.Errorf("failed to unmarshal position: %v", err)
 	}
 
-	doc, err := s.cache.get(protocol.URIFromPath(fileName))
+	doc, err := s.cache.Get(protocol.URIFromPath(fileName))
 	if err != nil {
 		return nil, utils.LogErrorf("evalItem: %s: %w", errorRetrievingDocument, err)
 	}
 
-	stack, err := processing.FindNodeByPosition(doc.ast, position.ProtocolToAST(p))
+	stack, err := processing.FindNodeByPosition(doc.AST, position.ProtocolToAST(p))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/formatting.go
+++ b/pkg/server/formatting.go
@@ -12,18 +12,18 @@ import (
 )
 
 func (s *Server) Formatting(_ context.Context, params *protocol.DocumentFormattingParams) ([]protocol.TextEdit, error) {
-	doc, err := s.cache.get(params.TextDocument.URI)
+	doc, err := s.cache.Get(params.TextDocument.URI)
 	if err != nil {
 		return nil, utils.LogErrorf("Formatting: %s: %w", errorRetrievingDocument, err)
 	}
 
-	formatted, err := formatter.Format(params.TextDocument.URI.SpanURI().Filename(), doc.item.Text, s.configuration.FormattingOptions)
+	formatted, err := formatter.Format(params.TextDocument.URI.SpanURI().Filename(), doc.Item.Text, s.configuration.FormattingOptions)
 	if err != nil {
 		log.Errorf("error formatting document: %v", err)
 		return nil, nil
 	}
 
-	return getTextEdits(doc.item.Text, formatted), nil
+	return getTextEdits(doc.Item.Text, formatted), nil
 }
 
 func getTextEdits(before, after string) []protocol.TextEdit {

--- a/pkg/server/symbols.go
+++ b/pkg/server/symbols.go
@@ -15,19 +15,19 @@ import (
 )
 
 func (s *Server) DocumentSymbol(_ context.Context, params *protocol.DocumentSymbolParams) ([]interface{}, error) {
-	doc, err := s.cache.get(params.TextDocument.URI)
+	doc, err := s.cache.Get(params.TextDocument.URI)
 	if err != nil {
 		return nil, utils.LogErrorf("DocumentSymbol: %s: %w", errorRetrievingDocument, err)
 	}
 
-	if doc.err != nil {
+	if doc.Err != nil {
 		// Returning an error too often can lead to the client killing the language server
 		// Logging the errors is sufficient
 		log.Errorf("DocumentSymbol: %s", errorParsingDocument)
 		return nil, nil
 	}
 
-	symbols := buildDocumentSymbols(doc.ast)
+	symbols := buildDocumentSymbols(doc.AST)
 
 	result := make([]interface{}, len(symbols))
 	for i, symbol := range symbols {


### PR DESCRIPTION
Closes https://github.com/grafana/jsonnet-language-server/issues/133

There are two caches currently:
- One for protocol documents. This one is instantiated by the server and maintained up-to-date as documents are opened, changed, and closed.
- One for jsonnet objects. This one is a global var and is only added to. Modified objects are never removed/modified from the cache.

By merging the two caches, we can expand the first cache's behavior to also invalidate modified objects from the global cache when a document is changed.