### PR TITLE
Simplify processing args

### DIFF
--- a/pkg/ast/processing/processor.go
+++ b/pkg/ast/processing/processor.go
@@ -1,0 +1,18 @@
+package processing
+
+import (
+	"github.com/google/go-jsonnet"
+	"github.com/grafana/jsonnet-language-server/pkg/cache"
+)
+
+type Processor struct {
+	cache *cache.Cache
+	vm    *jsonnet.VM
+}
+
+func NewProcessor(cache *cache.Cache, vm *jsonnet.VM) *Processor {
+	return &Processor{
+		cache: cache,
+		vm:    vm,
+	}
+}

--- a/pkg/ast/processing/top_level_objects.go
+++ b/pkg/ast/processing/top_level_objects.go
@@ -1,25 +1,23 @@
 package processing
 
 import (
-	"github.com/google/go-jsonnet"
 	"github.com/google/go-jsonnet/ast"
-	"github.com/grafana/jsonnet-language-server/pkg/cache"
 	"github.com/grafana/jsonnet-language-server/pkg/nodestack"
 	log "github.com/sirupsen/logrus"
 )
 
-func FindTopLevelObjectsInFile(cache *cache.Cache, vm *jsonnet.VM, filename, importedFrom string) []*ast.DesugaredObject {
-	v, ok := cache.GetTopLevelObject(filename, importedFrom)
+func (p *Processor) FindTopLevelObjectsInFile(filename, importedFrom string) []*ast.DesugaredObject {
+	v, ok := p.cache.GetTopLevelObject(filename, importedFrom)
 	if !ok {
-		rootNode, _, _ := vm.ImportAST(importedFrom, filename)
-		v = FindTopLevelObjects(cache, nodestack.NewNodeStack(rootNode), vm)
-		cache.PutTopLevelObject(filename, importedFrom, v)
+		rootNode, _, _ := p.vm.ImportAST(importedFrom, filename)
+		v = p.FindTopLevelObjects(nodestack.NewNodeStack(rootNode))
+		p.cache.PutTopLevelObject(filename, importedFrom, v)
 	}
 	return v
 }
 
 // Find all ast.DesugaredObject's from NodeStack
-func FindTopLevelObjects(cache *cache.Cache, stack *nodestack.NodeStack, vm *jsonnet.VM) []*ast.DesugaredObject {
+func (p *Processor) FindTopLevelObjects(stack *nodestack.NodeStack) []*ast.DesugaredObject {
 	var objects []*ast.DesugaredObject
 	for !stack.IsEmpty() {
 		curr := stack.Pop()
@@ -33,7 +31,7 @@ func FindTopLevelObjects(cache *cache.Cache, stack *nodestack.NodeStack, vm *jso
 			stack.Push(curr.Body)
 		case *ast.Import:
 			filename := curr.File.Value
-			rootNode, _, _ := vm.ImportAST(string(curr.Loc().File.DiagnosticFileName), filename)
+			rootNode, _, _ := p.vm.ImportAST(string(curr.Loc().File.DiagnosticFileName), filename)
 			stack.Push(rootNode)
 		case *ast.Index:
 			indexValue, indexIsString := curr.Index.(*ast.LiteralString)
@@ -44,7 +42,7 @@ func FindTopLevelObjects(cache *cache.Cache, stack *nodestack.NodeStack, vm *jso
 			var container ast.Node
 			// If our target is a var, the container for the index is the var ref
 			if varTarget, targetIsVar := curr.Target.(*ast.Var); targetIsVar {
-				ref, err := FindVarReference(varTarget, vm)
+				ref, err := p.FindVarReference(varTarget)
 				if err != nil {
 					log.WithError(err).Errorf("Error finding var reference, ignoring this node")
 					continue
@@ -61,7 +59,7 @@ func FindTopLevelObjects(cache *cache.Cache, stack *nodestack.NodeStack, vm *jso
 			if containerObj, containerIsObj := container.(*ast.DesugaredObject); containerIsObj {
 				possibleObjects = []*ast.DesugaredObject{containerObj}
 			} else if containerImport, containerIsImport := container.(*ast.Import); containerIsImport {
-				possibleObjects = FindTopLevelObjectsInFile(cache, vm, containerImport.File.Value, string(containerImport.Loc().File.DiagnosticFileName))
+				possibleObjects = p.FindTopLevelObjectsInFile(containerImport.File.Value, string(containerImport.Loc().File.DiagnosticFileName))
 			}
 
 			for _, obj := range possibleObjects {
@@ -70,7 +68,7 @@ func FindTopLevelObjects(cache *cache.Cache, stack *nodestack.NodeStack, vm *jso
 				}
 			}
 		case *ast.Var:
-			varReference, err := FindVarReference(curr, vm)
+			varReference, err := p.FindVarReference(curr)
 			if err != nil {
 				log.WithError(err).Errorf("Error finding var reference, ignoring this node")
 				continue

--- a/pkg/server/completion.go
+++ b/pkg/server/completion.go
@@ -84,7 +84,8 @@ func (s *Server) completionFromStack(line string, stack *nodestack.NodeStack, vm
 		return items
 	}
 
-	ranges, err := processing.FindRangesFromIndexList(s.cache, stack, indexes, vm, true)
+	processor := processing.NewProcessor(s.cache, vm)
+	ranges, err := processor.FindRangesFromIndexList(stack, indexes, true)
 	if err != nil {
 		log.Errorf("Completion: error finding ranges: %v", err)
 		return []protocol.CompletionItem{}

--- a/pkg/server/definition.go
+++ b/pkg/server/definition.go
@@ -63,6 +63,7 @@ func (s *Server) definitionLink(params *protocol.DefinitionParams) ([]protocol.D
 
 func (s *Server) findDefinition(root ast.Node, params *protocol.DefinitionParams, vm *jsonnet.VM) ([]protocol.DefinitionLink, error) {
 	var response []protocol.DefinitionLink
+	processor := processing.NewProcessor(s.cache, vm)
 
 	searchStack, _ := processing.FindNodeByPosition(root, position.ProtocolToAST(params.Position))
 	deepestNode := searchStack.Pop()
@@ -93,7 +94,7 @@ func (s *Server) findDefinition(root ast.Node, params *protocol.DefinitionParams
 		indexSearchStack := nodestack.NewNodeStack(deepestNode)
 		indexList := indexSearchStack.BuildIndexList()
 		tempSearchStack := *searchStack
-		objectRanges, err := processing.FindRangesFromIndexList(s.cache, &tempSearchStack, indexList, vm, false)
+		objectRanges, err := processor.FindRangesFromIndexList(&tempSearchStack, indexList, false)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Instead of carrying a `cache` and `vm` around on each function, create a `Processor` struct to contain those