### PR TITLE
Invalidate the whole "top level objects" cache

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 
@@ -56,11 +55,9 @@ func (c *Cache) Put(new *Document) error {
 	c.docs[uri] = new
 
 	// Invalidate the TopLevelObject cache
-	for k := range c.topLevelObjects {
-		if strings.HasSuffix(k, filepath.Base(uri.SpanURI().Filename())) {
-			delete(c.topLevelObjects, k)
-		}
-	}
+	// We can't easily invalidate the cache for a single file (hard to figure out where the import actually leads),
+	// so we just clear the whole thing
+	c.topLevelObjects = make(map[string][]*ast.DesugaredObject)
 
 	return nil
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -105,7 +105,8 @@ func (s *Server) DidChange(_ context.Context, params *protocol.DidChangeTextDocu
 			}
 		}
 	}
-	return nil
+
+	return s.cache.Put(doc)
 }
 
 func (s *Server) DidOpen(_ context.Context, params *protocol.DidOpenTextDocumentParams) (err error) {


### PR DESCRIPTION
... whenever files are changed. The reason for that is that it's hard to figure out where imports actually lead, so invalidations sometimes won't happen, leading to invalid language server suggestions