### PR TITLE
Include all in-scope locals in completion

### DIFF
--- a/pkg/server/completion.go
+++ b/pkg/server/completion.go
@@ -69,14 +69,19 @@ func (s *Server) completionFromStack(line string, stack *nodestack.NodeStack, vm
 		items := []protocol.CompletionItem{}
 		// firstIndex is a variable (local) completion
 		for !stack.IsEmpty() {
-			if curr, ok := stack.Pop().(*ast.Local); ok {
-				for _, bind := range curr.Binds {
-					label := string(bind.Variable)
-
-					if !strings.HasPrefix(label, indexes[0]) {
-						continue
-					}
-
+			curr := stack.Pop()
+			var binds ast.LocalBinds
+			switch typedCurr := curr.(type) {
+			case *ast.DesugaredObject:
+				binds = typedCurr.Locals
+			case *ast.Local:
+				binds = typedCurr.Binds
+			default:
+				continue
+			}
+			for _, bind := range binds {
+				label := string(bind.Variable)
+				if strings.HasPrefix(label, indexes[0]) && label != "$" {
 					items = append(items, createCompletionItem(label, "", protocol.VariableCompletion, bind.Body, position))
 				}
 			}

--- a/pkg/server/completion_test.go
+++ b/pkg/server/completion_test.go
@@ -221,15 +221,26 @@ func TestCompletion(t *testing.T) {
 			replaceByString: "bar: ",
 			expected: protocol.CompletionList{
 				IsIncomplete: false,
-				Items: []protocol.CompletionItem{{
-					Label:      "somevar",
-					Kind:       protocol.VariableCompletion,
-					Detail:     "somevar",
-					InsertText: "somevar",
-					LabelDetails: protocol.CompletionItemLabelDetails{
-						Description: "string",
+				Items: []protocol.CompletionItem{
+					{
+						Label:      "somevar2",
+						Kind:       protocol.VariableCompletion,
+						Detail:     "somevar2",
+						InsertText: "somevar2",
+						LabelDetails: protocol.CompletionItemLabelDetails{
+							Description: "string",
+						},
 					},
-				}},
+					{
+						Label:      "somevar",
+						Kind:       protocol.VariableCompletion,
+						Detail:     "somevar",
+						InsertText: "somevar",
+						LabelDetails: protocol.CompletionItemLabelDetails{
+							Description: "string",
+						},
+					},
+				},
 			},
 		},
 		{
@@ -239,15 +250,26 @@ func TestCompletion(t *testing.T) {
 			replaceByString: "bar: some",
 			expected: protocol.CompletionList{
 				IsIncomplete: false,
-				Items: []protocol.CompletionItem{{
-					Label:      "somevar",
-					Kind:       protocol.VariableCompletion,
-					Detail:     "somevar",
-					InsertText: "somevar",
-					LabelDetails: protocol.CompletionItemLabelDetails{
-						Description: "string",
+				Items: []protocol.CompletionItem{
+					{
+						Label:      "somevar2",
+						Kind:       protocol.VariableCompletion,
+						Detail:     "somevar2",
+						InsertText: "somevar2",
+						LabelDetails: protocol.CompletionItemLabelDetails{
+							Description: "string",
+						},
 					},
-				}},
+					{
+						Label:      "somevar",
+						Kind:       protocol.VariableCompletion,
+						Detail:     "somevar",
+						InsertText: "somevar",
+						LabelDetails: protocol.CompletionItemLabelDetails{
+							Description: "string",
+						},
+					},
+				},
 			},
 		},
 		{

--- a/pkg/server/definition_test.go
+++ b/pkg/server/definition_test.go
@@ -232,12 +232,12 @@ var definitionTestCases = []definitionTestCase{
 		results: []definitionResult{{
 			targetFilename: "testdata/basic-object.jsonnet",
 			targetRange: protocol.Range{
-				Start: protocol.Position{Line: 5, Character: 2},
-				End:   protocol.Position{Line: 5, Character: 12},
+				Start: protocol.Position{Line: 6, Character: 2},
+				End:   protocol.Position{Line: 6, Character: 12},
 			},
 			targetSelectionRange: protocol.Range{
-				Start: protocol.Position{Line: 5, Character: 2},
-				End:   protocol.Position{Line: 5, Character: 5},
+				Start: protocol.Position{Line: 6, Character: 2},
+				End:   protocol.Position{Line: 6, Character: 5},
 			},
 		}},
 	},
@@ -248,12 +248,12 @@ var definitionTestCases = []definitionTestCase{
 		results: []definitionResult{{
 			targetFilename: "testdata/basic-object.jsonnet",
 			targetRange: protocol.Range{
-				Start: protocol.Position{Line: 5, Character: 2},
-				End:   protocol.Position{Line: 5, Character: 12},
+				Start: protocol.Position{Line: 6, Character: 2},
+				End:   protocol.Position{Line: 6, Character: 12},
 			},
 			targetSelectionRange: protocol.Range{
-				Start: protocol.Position{Line: 5, Character: 2},
-				End:   protocol.Position{Line: 5, Character: 5},
+				Start: protocol.Position{Line: 6, Character: 2},
+				End:   protocol.Position{Line: 6, Character: 5},
 			},
 		}},
 	},

--- a/pkg/server/symbols_test.go
+++ b/pkg/server/symbols_test.go
@@ -106,21 +106,21 @@ func TestSymbols(t *testing.T) {
 					Kind:   protocol.Field,
 					Range: protocol.Range{
 						Start: protocol.Position{
-							Line:      5,
+							Line:      6,
 							Character: 2,
 						},
 						End: protocol.Position{
-							Line:      5,
+							Line:      6,
 							Character: 12,
 						},
 					},
 					SelectionRange: protocol.Range{
 						Start: protocol.Position{
-							Line:      5,
+							Line:      6,
 							Character: 2,
 						},
 						End: protocol.Position{
-							Line:      5,
+							Line:      6,
 							Character: 5,
 						},
 					},

--- a/pkg/server/testdata/basic-object.jsonnet
+++ b/pkg/server/testdata/basic-object.jsonnet
@@ -3,5 +3,6 @@ local somevar = 'hello';
 {
   foo: 'bar',
 } + {
+  local somevar2 = 'world',
   bar: 'foo',
 }


### PR DESCRIPTION
* Enables auto-complete for variables scoped to current object node, instead of just globally defined variables

Closes #180 