### PR TITLE
Fix symbols crashing

### DIFF
--- a/pkg/ast/processing/find_field.go
+++ b/pkg/ast/processing/find_field.go
@@ -96,7 +96,7 @@ func (p *Processor) extractObjectRangesFromDesugaredObjs(desugaredObjs []*ast.De
 		}
 		if len(indexList) == 0 {
 			for _, found := range foundFields {
-				ranges = append(ranges, FieldToRange(*found))
+				ranges = append(ranges, p.FieldToRange(*found))
 
 				// If the field is not PlusSuper (field+: value), we stop there. Other previous values are not relevant
 				// If partialMatchCurrentField is true, we can continue to look for other fields

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -107,7 +107,11 @@ func (c *Cache) GetContents(uri protocol.DocumentURI, position protocol.Range) (
 	for i := position.Start.Line; i <= position.End.Line; i++ {
 		switch i {
 		case position.Start.Line:
-			contentBuilder.WriteString(lines[i][position.Start.Character:])
+			if i == position.End.Line {
+				contentBuilder.WriteString(lines[i][position.Start.Character:position.End.Character])
+			} else {
+				contentBuilder.WriteString(lines[i][position.Start.Character:])
+			}
 		case position.End.Line:
 			contentBuilder.WriteString(lines[i][:position.End.Character])
 		default:

--- a/pkg/server/hover_test.go
+++ b/pkg/server/hover_test.go
@@ -259,7 +259,7 @@ func TestHover(t *testing.T) {
 			expectedContent: protocol.Hover{
 				Contents: protocol.MarkupContent{
 					Kind:  protocol.Markdown,
-					Value: "```jsonnet\nbar: 'innerfoo',\n```\n",
+					Value: "```jsonnet\nbar: 'innerfoo'\n```\n",
 				},
 				Range: protocol.Range{
 					Start: protocol.Position{Line: 9, Character: 5},

--- a/pkg/server/symbols_test.go
+++ b/pkg/server/symbols_test.go
@@ -266,6 +266,112 @@ func TestSymbols(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:     "Conditional fields",
+			filename: "testdata/conditional-fields.jsonnet",
+			expectSymbols: []interface{}{
+				protocol.DocumentSymbol{
+					Name:   "flag",
+					Detail: "Boolean",
+					Kind:   protocol.Variable,
+					Range: protocol.Range{
+						Start: protocol.Position{
+							Line:      0,
+							Character: 6,
+						},
+						End: protocol.Position{
+							Line:      0,
+							Character: 17,
+						},
+					},
+					SelectionRange: protocol.Range{
+						Start: protocol.Position{
+							Line:      0,
+							Character: 6,
+						},
+						End: protocol.Position{
+							Line:      0,
+							Character: 10,
+						},
+					},
+				},
+				protocol.DocumentSymbol{
+					Name:   "if flag then 'hello'",
+					Detail: "String",
+					Kind:   protocol.Field,
+					Range: protocol.Range{
+						Start: protocol.Position{
+							Line:      2,
+							Character: 2,
+						},
+						End: protocol.Position{
+							Line:      2,
+							Character: 34,
+						},
+					},
+					SelectionRange: protocol.Range{
+						Start: protocol.Position{
+							Line:      2,
+							Character: 2,
+						},
+						End: protocol.Position{
+							Line:      2,
+							Character: 22,
+						},
+					},
+				},
+				protocol.DocumentSymbol{
+					Name:   "if flag then 'hello1' else 'hello2'",
+					Detail: "String",
+					Kind:   protocol.Field,
+					Range: protocol.Range{
+						Start: protocol.Position{
+							Line:      3,
+							Character: 2,
+						},
+						End: protocol.Position{
+							Line:      3,
+							Character: 49,
+						},
+					},
+					SelectionRange: protocol.Range{
+						Start: protocol.Position{
+							Line:      3,
+							Character: 2,
+						},
+						End: protocol.Position{
+							Line:      3,
+							Character: 37,
+						},
+					},
+				},
+				protocol.DocumentSymbol{
+					Name:   "if false == flag then 'hello3' else (function() 'test')()",
+					Detail: "String",
+					Kind:   protocol.Field,
+					Range: protocol.Range{
+						Start: protocol.Position{
+							Line:      4,
+							Character: 2,
+						},
+						End: protocol.Position{
+							Line:      4,
+							Character: 71,
+						},
+					},
+					SelectionRange: protocol.Range{
+						Start: protocol.Position{
+							Line:      4,
+							Character: 2,
+						},
+						End: protocol.Position{
+							Line:      4,
+							Character: 59,
+						},
+					},
+				},
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			params := &protocol.DocumentSymbolParams{

--- a/pkg/server/testdata/conditional-fields.jsonnet
+++ b/pkg/server/testdata/conditional-fields.jsonnet
@@ -1,0 +1,6 @@
+local flag = true;
+{
+  [if flag then 'hello']: 'world!',
+  [if flag then 'hello1' else 'hello2']: 'world!',
+  [if false == flag then 'hello3' else (function() 'test')()]: 'world!',
+}


### PR DESCRIPTION
Closes https://github.com/grafana/jsonnet-language-server/issues/166

Symbols are now always strings. If field names are complex nodes, then we use the actual jsonnet