### PR TITLE
Apply StepSecurity and zizmor fixes

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
         with:

--- a/.github/workflows/jsonnetfmt.yml
+++ b/.github/workflows/jsonnetfmt.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
           go-version-file: go.mod

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - '*'
-  
 permissions:
   contents: read
 
@@ -15,9 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
           go-version-file: go.mod
+          cache: false
       - uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf # v6.1.0
         with:
           version: latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,12 +6,13 @@ on:
   pull_request: {}
 permissions:
   contents: read
-
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
           go-version-file: go.mod


### PR DESCRIPTION
Securing GH actions as followup from [the incident on April 26th 2025](https://grafana.com/blog/2025/04/27/grafana-security-update-no-customer-impact-from-github-workflow-vulnerability/).

<details><summary>before</summary>
<p>

```
$ git remote -v; zizmor --gh-token=$(gh auth token) .
origin	https://github.com/grafana/jsonnet-language-server.git (fetch)
origin	https://github.com/grafana/jsonnet-language-server.git (push)
 INFO audit: zizmor: 🌈 completed ./.github/workflows/golangci-lint.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/jsonnetfmt.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/release.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/test.yml
warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/golangci-lint.yml:14:9
   |
14 |       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
   |         ------------------------------------------------------------------------ does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/jsonnetfmt.yml:11:9
   |
11 |       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
   |         ------------------------------------------------------------------------ does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/jsonnetfmt.yml:8:3
   |
 8 | /   jsonnetfmt:
 9 | |     runs-on: ubuntu-latest
...  |
24 | |             exit 1
25 | |           }
   | |            -
   | |____________|
   |              this job
   |              default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/release.yml:12:9
   |
12 |       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
   |         ------------------------------------------------------------------------ does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/release.yml:9:3
   |
 9 | /   goreleaser:
10 | |     runs-on: ubuntu-latest
...  |
20 | |         env:
21 | |           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   | |                                                    -
   | |____________________________________________________|
   |                                                      this job
   |                                                      default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
  --> ./.github/workflows/release.yml:3:1
   |
 3 | / on:
 4 | |   push:
 5 | |     tags:
 6 | |       - '*'
   | |___________^ generally used when publishing artifacts generated at runtime
 7 |
...
12 |         - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
13 |         - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cache enabled by default here
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/test.yml:11:9
   |
11 |       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
   |         ------------------------------------------------------------------------ does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/test.yml:8:3
   |
 8 | /   test:
 9 | |     runs-on: ubuntu-latest
...  |
15 | |       - run: go test ./... -bench=. -benchmem
16 | |
   | |      -
   | |______|
   |        this job
   |        default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

11 findings (3 suppressed): 0 unknown, 0 informational, 0 low, 7 medium, 1 high
```

</p>
</details> 

<details><summary>after</summary>
<p>

```
$ git remote -v; zizmor --gh-token=$(gh auth token) .
origin	https://github.com/bobdanek/jsonnet-language-server.git (fetch)
origin	https://github.com/bobdanek/jsonnet-language-server.git (push)
upstream	https://github.com/grafana/jsonnet-language-server.git (fetch)
upstream	https://github.com/grafana/jsonnet-language-server.git (push)
 INFO audit: zizmor: 🌈 completed ./.github/workflows/golangci-lint.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/jsonnetfmt.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/release.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/test.yml
No findings to report. Good job!
```

</p>
</details> 