### PR TITLE
feat: allow external eval binary (jsonnet or tk)

### DIFF
--- a/pkg/server/configuration.go
+++ b/pkg/server/configuration.go
@@ -23,6 +23,9 @@ type Configuration struct {
 	EnableEvalDiagnostics     bool
 	EnableLintDiagnostics     bool
 	ShowDocstringInCompletion bool
+
+	// EvalBinary is the external command for evaluation (e.g. "jsonnet"). When non-empty, jsonnet.evalFile and jsonnet.evalExpression use it instead of the in-process VM.
+	EvalBinary string
 }
 
 func (s *Server) DidChangeConfiguration(_ context.Context, params *protocol.DidChangeConfigurationParams) error {
@@ -101,6 +104,12 @@ func (s *Server) DidChangeConfiguration(_ context.Context, params *protocol.DidC
 				return fmt.Errorf("%w: ext_code parsing failed: %v", jsonrpc2.ErrInvalidParams, err)
 			}
 			s.configuration.ExtCode = newCode
+		case "eval_binary":
+			if cmd, ok := sv.(string); ok {
+				s.configuration.EvalBinary = cmd
+			} else {
+				return fmt.Errorf("%w: unsupported settings value for eval_binary. expected string. got: %T", jsonrpc2.ErrInvalidParams, sv)
+			}
 
 		default:
 			return fmt.Errorf("%w: unsupported settings key: %q", jsonrpc2.ErrInvalidParams, sk)

--- a/pkg/server/execute.go
+++ b/pkg/server/execute.go
@@ -4,7 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"reflect"
+	"strings"
 
 	"github.com/grafana/jsonnet-language-server/pkg/ast/processing"
 	position "github.com/grafana/jsonnet-language-server/pkg/position_conversion"
@@ -80,13 +84,94 @@ func (s *Server) evalExpression(params *protocol.ExecuteCommandParams) (interfac
 		return nil, fmt.Errorf("failed to unmarshal expression: %v", err)
 	}
 
-	// TODO: Replace this stuff with Tanka's `eval` code
-	vm := s.getVM(fileName)
-
 	script := fmt.Sprintf("local main = (import '%s');\nmain", fileName)
 	if expression != "" {
 		script += "." + expression
 	}
 
+	if s.configuration.EvalBinary != "" {
+		return s.runEvalExternal(fileName, expression)
+	}
+
+	log.Infof("evaluating internally: file=%s expression=%q", fileName, expression)
+	vm := s.getVM(fileName)
 	return vm.EvaluateAnonymousSnippet(fileName, script)
+}
+
+// runEvalExternal runs the configured external command. When ResolvePathsWithTanka is set,
+// EvalBinary is invoked as a Tanka binary (e.g. "tk eval <path>"). Otherwise it is invoked
+// as a jsonnet binary (temp script file with -J, -V, --ext-code).
+func (s *Server) runEvalExternal(fileName, expression string) (string, error) {
+	absPath, err := filepath.Abs(fileName)
+	if err != nil {
+		return "", fmt.Errorf("eval: resolving path: %w", err)
+	}
+
+	if s.configuration.ResolvePathsWithTanka {
+		return s.runEvalTanka(absPath, expression)
+	}
+	return s.runEvalJsonnet(absPath, expression)
+}
+
+// runEvalTanka invokes EvalBinary as a Tanka binary: tk eval <envDir> [-e expr] [-V ...] [--ext-code ...].
+// envDir is the directory containing the file (e.g. the environment directory with main.jsonnet).
+func (s *Server) runEvalTanka(absPath, expression string) (string, error) {
+	envDir := filepath.Dir(absPath)
+	args := []string{"eval", envDir}
+	if expression != "" {
+		args = append(args, "-e", expression)
+	}
+	for k, v := range s.configuration.ExtVars {
+		args = append(args, "-V", k+"="+v)
+	}
+	for k, v := range s.configuration.ExtCode {
+		args = append(args, "--ext-code", k+"="+v)
+	}
+	log.Infof("evaluating with external command: %s %s", s.configuration.EvalBinary, strings.Join(args, " "))
+	cmd := exec.CommandContext(context.Background(), s.configuration.EvalBinary, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("eval %s: %w\n%s", s.configuration.EvalBinary, err, out)
+	}
+	return strings.TrimSuffix(string(out), "\n"), nil
+}
+
+// runEvalJsonnet invokes EvalBinary as a jsonnet binary: jsonnet -J ... -V ... --ext-code ... <script.jsonnet>.
+func (s *Server) runEvalJsonnet(absPath, expression string) (string, error) {
+	script := fmt.Sprintf("local main = (import %q);\nmain", absPath)
+	if expression != "" {
+		script += "." + expression
+	}
+	jpaths := append(s.configuration.JPaths, filepath.Dir(absPath))
+	args := make([]string, 0, 4+len(jpaths)*2+len(s.configuration.ExtVars)*2+len(s.configuration.ExtCode)*2+2)
+	for _, p := range jpaths {
+		args = append(args, "-J", p)
+	}
+	for k, v := range s.configuration.ExtVars {
+		args = append(args, "-V", k+"="+v)
+	}
+	for k, v := range s.configuration.ExtCode {
+		args = append(args, "--ext-code", k+"="+v)
+	}
+	tmp, err := os.CreateTemp("", "jsonnet-eval-*.jsonnet")
+	if err != nil {
+		return "", fmt.Errorf("eval: creating temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if _, err := tmp.WriteString(script); err != nil {
+		tmp.Close()
+		return "", fmt.Errorf("eval: writing script: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return "", fmt.Errorf("eval: closing temp file: %w", err)
+	}
+	args = append(args, tmpPath)
+	log.Infof("evaluating with external command: %s %s", s.configuration.EvalBinary, strings.Join(args, " "))
+	cmd := exec.CommandContext(context.Background(), s.configuration.EvalBinary, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("eval %s: %w\n%s", s.configuration.EvalBinary, err, out)
+	}
+	return strings.TrimSuffix(string(out), "\n"), nil
 }

--- a/pkg/server/execute.go
+++ b/pkg/server/execute.go
@@ -142,7 +142,9 @@ func (s *Server) runEvalJsonnet(absPath, expression string) (string, error) {
 	if expression != "" {
 		script += "." + expression
 	}
-	jpaths := append(s.configuration.JPaths, filepath.Dir(absPath))
+	jpaths := make([]string, 0, len(s.configuration.JPaths)+1)
+	jpaths = append(jpaths, s.configuration.JPaths...)
+	jpaths = append(jpaths, filepath.Dir(absPath))
 	args := make([]string, 0, 4+len(jpaths)*2+len(s.configuration.ExtVars)*2+len(s.configuration.ExtCode)*2+2)
 	for _, p := range jpaths {
 		args = append(args, "-J", p)

--- a/pkg/utils/strings.go
+++ b/pkg/utils/strings.go
@@ -1,3 +1,4 @@
+//revive:disable-next-line:var-naming package name is a project convention
 package utils
 
 import "regexp"


### PR DESCRIPTION
## Summary
When `eval_binary` is set in config, `jsonnet.evalFile` and `jsonnet.evalExpression` use that command instead of the in-process VM.

## Behavior
- **Tanka mode** (`resolve_paths_with_tanka: true`): EvalBinary is invoked as a Tanka binary, e.g. `tk eval <envDir> [-e expr] [-V ...] [--ext-code ...]`. Tanka resolves jpath (lib, vendor) from the path.
- **Jsonnet mode** (`resolve_paths_with_tanka: false`): EvalBinary is invoked as a jsonnet binary with a temp script file and `-J`, `-V`, `--ext-code` (works with jsonnet and jrsonnet).

## Config
- New setting: `eval_binary` (string). Example: `"jsonnet"`, `"jrsonnet"`, or `"tk"` when using Tanka.
- Logs whether evaluation is internal or external and the command/args used.

Made with [Cursor](https://cursor.com)