### PR TITLE
fix(deps): update go-jsonnet to v0.22.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,10 @@
 module github.com/grafana/jsonnet-language-server
 
-go 1.24.0
-
-toolchain go1.24.2
+go 1.24.5
 
 require (
 	github.com/JohannesKaufmann/html-to-markdown v1.6.0
-	github.com/google/go-jsonnet v0.21.0
+	github.com/google/go-jsonnet v0.22.0
 	github.com/grafana/tanka v0.32.1-0.20250521123240-fa219d35d24f
 	github.com/hexops/gotextdiff v1.0.3
 	github.com/jdbaldry/go-language-server-protocol v0.0.0-20211013214444-3022da0884b2

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5x
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/go-jsonnet v0.21.0 h1:43Bk3K4zMRP/aAZm9Po2uSEjY6ALCkYUVIcz9HLGMvA=
-github.com/google/go-jsonnet v0.21.0/go.mod h1:tCGAu8cpUpEZcdGMmdOu37nh8bGgqubhI5v2iSk3KJQ=
+github.com/google/go-jsonnet v0.22.0 h1:o0bOAIE+9SIfRZ7FXQPuta0mHLLE0AwbY/L5GTH5CH8=
+github.com/google/go-jsonnet v0.22.0/go.mod h1:pLhKpu0/ODjL2Zev4y+CmCoHKAgONT1gSLQyriuYh9w=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grafana/tanka v0.32.1-0.20250521123240-fa219d35d24f h1:gP0r33Vy4+UwxSisoUvCT8H2QClu96X7SMakqG9iE6Q=


### PR DESCRIPTION
Fixes #270.

go-jsonnet v0.21.0 does not desugar the index expression of a `super[e]` access, leaving a nil node that makes the static analyzer panic with `Unexpected node <nil>`. Because `DidOpen`/`DidChange` call `SnippetToAST` directly, the panic takes down the server process; the client then restarts it and re-opens the same document, so any workspace containing such a file is stuck in a crash loop.

Fixed upstream in google/go-jsonnet#849, released in v0.22.0. This is the same bump Renovate proposed in #258, which was autoclosed after a transient `go mod tidy` TLS timeout rather than a real incompatibility.

### Verification

- `go build ./...` succeeds with no source changes; `go test ./...` passes.
- Drove both builds over LSP stdio with `initialize` + `didOpen` of a file containing `super[f.key]`: the v0.21.0 build exits 2 with the panic, this build stays alive.

### Note on the `go` directive

`go mod tidy` raises `go` from 1.24.0 to 1.24.5 and drops the now-redundant `toolchain go1.24.2` line, because go-jsonnet v0.22.0 requires Go 1.24.5. CI resolves its Go version from `go-version-file: go.mod`, so it picks this up automatically.
